### PR TITLE
Fix coreLogic code path with null build parameter

### DIFF
--- a/src/main/java/com/openshift/jenkins/plugins/pipeline/OpenShiftCreator.java
+++ b/src/main/java/com/openshift/jenkins/plugins/pipeline/OpenShiftCreator.java
@@ -162,7 +162,7 @@ public class OpenShiftCreator extends Builder implements SimpleBuildStep, Serial
 		String className = this.getClass().getName();
 		HashMap<String,String> overridenFields = new HashMap<String,String>();
 		try {
-			EnvVars env = build.getEnvironment(listener);
+			EnvVars env = (build != null ? build.getEnvironment(listener) : null);
 			if (env == null)
 				return overridenFields;
 			Class<?> c = Class.forName(className);


### PR DESCRIPTION
When coreLogic is called with a null build parameter, inspectBuildEnvAndOverrideFields throws a NullPointer exception on build.getEnvironment(listener) call.
