### PR TITLE
move to 5.0.0 snapshot, including new auth model with okhttp, resulti…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,9 +69,19 @@
   
   <dependencies>
 	<dependency>
+  		<groupId>com.squareup.okhttp3</groupId>
+  		<artifactId>okhttp</artifactId>
+  		<version>3.3.1</version>
+	</dependency>
+	<dependency>
+			<groupId>org.jboss</groupId>
+			<artifactId>jboss-dmr</artifactId>
+			<version>1.3.0.Final</version>
+		</dependency>
+	<dependency>
 	    <groupId>com.openshift</groupId>
 	    <artifactId>openshift-restclient-java</artifactId>
-	    <version>4.0.3.Final</version>
+	    <version>5.0.0-SNAPSHOT</version>
 	</dependency>
     
   	<dependency>

--- a/src/main/java/com/openshift/jenkins/plugins/pipeline/OpenShiftBasePostAction.java
+++ b/src/main/java/com/openshift/jenkins/plugins/pipeline/OpenShiftBasePostAction.java
@@ -4,7 +4,7 @@ import java.io.IOException;
 import java.io.Serializable;
 
 import com.openshift.jenkins.plugins.pipeline.model.IOpenShiftPlugin;
-import com.openshift.restclient.authorization.TokenAuthorizationStrategy;
+//import com.openshift.restclient.authorization.TokenAuthorizationStrategy;
 
 import jenkins.tasks.SimpleBuildStep;
 import hudson.FilePath;
@@ -22,7 +22,7 @@ public abstract class OpenShiftBasePostAction extends Recorder implements Simple
     protected final String namespace;
     protected final String authToken;
     protected final String verbose;
-    protected transient TokenAuthorizationStrategy bearerToken;
+    //protected transient TokenAuthorizationStrategy bearerToken;
     protected transient Auth auth;
 
     public OpenShiftBasePostAction(String apiURL, String namespace, String authToken, String verbose) {
@@ -58,21 +58,21 @@ public abstract class OpenShiftBasePostAction extends Recorder implements Simple
 		this.auth = auth;
 	}
 
-	@Override
+/*	@Override
 	public void setToken(TokenAuthorizationStrategy token) {
 		this.bearerToken = token;
 	}
-    
+*/    
     @Override
 	public Auth getAuth() {
 		return auth;
 	}
 
-	@Override
+/*	@Override
 	public TokenAuthorizationStrategy getToken() {
 		return bearerToken;
 	}
-
+*/
 	@Override
 	public String getBaseClassName() {
 		return OpenShiftBasePostAction.class.getName();

--- a/src/main/java/com/openshift/jenkins/plugins/pipeline/OpenShiftBaseStep.java
+++ b/src/main/java/com/openshift/jenkins/plugins/pipeline/OpenShiftBaseStep.java
@@ -4,7 +4,7 @@ import java.io.IOException;
 import java.io.Serializable;
 
 import com.openshift.jenkins.plugins.pipeline.model.IOpenShiftPlugin;
-import com.openshift.restclient.authorization.TokenAuthorizationStrategy;
+//import com.openshift.restclient.authorization.TokenAuthorizationStrategy;
 
 import jenkins.tasks.SimpleBuildStep;
 import hudson.FilePath;
@@ -22,7 +22,7 @@ public abstract class OpenShiftBaseStep extends Builder  implements SimpleBuildS
     protected final String authToken;
     protected final String verbose;
     // marked transient so don't serialize these next 2 in the workflow plugin flow; constructed on per request basis
-    protected transient TokenAuthorizationStrategy bearerToken;
+    //protected transient TokenAuthorizationStrategy bearerToken;
     protected transient Auth auth;
     
     protected OpenShiftBaseStep(String apiURL, String namespace, String authToken, String verbose) {
@@ -63,7 +63,7 @@ public abstract class OpenShiftBaseStep extends Builder  implements SimpleBuildS
 		return auth;
 	}
 	
-	@Override
+/*	@Override
 	public TokenAuthorizationStrategy getToken() {
 		return bearerToken;
 	}
@@ -72,7 +72,7 @@ public abstract class OpenShiftBaseStep extends Builder  implements SimpleBuildS
 	public void setToken(TokenAuthorizationStrategy token) {
 		this.bearerToken = token;
 	}
-
+*/
 	@Override
 	public String getBaseClassName() {
 		return OpenShiftBaseStep.class.getName();

--- a/src/main/java/com/openshift/jenkins/plugins/pipeline/OpenShiftBuildCanceller.java
+++ b/src/main/java/com/openshift/jenkins/plugins/pipeline/OpenShiftBuildCanceller.java
@@ -12,7 +12,7 @@ import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.QueryParameter;
 
-import com.openshift.internal.restclient.http.HttpClientException;
+//import com.openshift.internal.restclient.http.HttpClientException;
 import com.openshift.restclient.IClient;
 import com.openshift.restclient.ResourceKind;
 import com.openshift.restclient.capability.CapabilityVisitor;
@@ -64,8 +64,8 @@ public class OpenShiftBuildCanceller extends OpenShiftBasePostAction {
     	IClient client = getClient(listener, DISPLAY_NAME, overrides);
     	
     	if (client != null) {
-			try {
-				List<IBuild> list = client.list(ResourceKind.BUILD, getNamespace(overrides));
+/*			try {
+*/				List<IBuild> list = client.list(ResourceKind.BUILD, getNamespace(overrides));
 				int count = 0;
 				for (IBuild bld : list) {
 					String phaseStr = bld.getStatus();
@@ -95,11 +95,11 @@ public class OpenShiftBuildCanceller extends OpenShiftBasePostAction {
 		    	listener.getLogger().println(String.format(MessageConstants.EXIT_BUILD_CANCEL, DISPLAY_NAME, count));
 				
 				return true;
-			} catch (HttpClientException e1) {
+/*			} catch (HttpClientException e1) {
 				e1.printStackTrace(listener.getLogger());
 				return false;
 			}
-    	} else {
+*/    	} else {
     		return false;
     	}
 	}

--- a/src/main/java/com/openshift/jenkins/plugins/pipeline/OpenShiftImageStreams.java
+++ b/src/main/java/com/openshift/jenkins/plugins/pipeline/OpenShiftImageStreams.java
@@ -16,7 +16,7 @@ import org.kohsuke.stapler.StaplerRequest;
 import com.openshift.jenkins.plugins.pipeline.model.IOpenShiftPlugin;
 import com.openshift.restclient.IClient;
 import com.openshift.restclient.ResourceKind;
-import com.openshift.restclient.authorization.TokenAuthorizationStrategy;
+//import com.openshift.restclient.authorization.TokenAuthorizationStrategy;
 import com.openshift.restclient.model.IImageStream;
 
 import hudson.Extension;
@@ -49,7 +49,7 @@ public class OpenShiftImageStreams extends SCM implements IOpenShiftPlugin {
     protected final String verbose;
     protected String lastCommitId = null;
     // marked transient so don't serialize these next 3 in the workflow plugin flow; constructed on per request basis
-    protected transient TokenAuthorizationStrategy bearerToken;
+    //protected transient TokenAuthorizationStrategy bearerToken;
     protected transient Auth auth;
     
     // Fields in config.jelly must match the parameter names in the "DataBoundConstructor"
@@ -105,7 +105,7 @@ public class OpenShiftImageStreams extends SCM implements IOpenShiftPlugin {
 		
     	// get oc client (sometime REST, sometimes Exec of oc command
     	setAuth(Auth.createInstance(null, getApiURL(overrides), overrides));
-    	setToken(new TokenAuthorizationStrategy(Auth.deriveBearerToken(null, authToken, listener, chatty)));		
+    	//setToken(new TokenAuthorizationStrategy(Auth.deriveBearerToken(null, authToken, listener, chatty)));		
     	// get oc client 
     	IClient client = this.getClient(listener, DISPLAY_NAME, overrides);
     	
@@ -268,11 +268,11 @@ public class OpenShiftImageStreams extends SCM implements IOpenShiftPlugin {
 		this.auth = auth;
 	}
 
-	@Override
+/*	@Override
 	public void setToken(TokenAuthorizationStrategy token) {
 		this.bearerToken = token;
 	}
-
+*/
 	@Override
 	public boolean coreLogic(Launcher launcher, TaskListener listener, Map<String,String> overrides) {
 		return false;
@@ -283,11 +283,11 @@ public class OpenShiftImageStreams extends SCM implements IOpenShiftPlugin {
 		return auth;
 	}
 
-	@Override
+/*	@Override
 	public TokenAuthorizationStrategy getToken() {
 		return bearerToken;
 	}
-
+*/
 
 
 }

--- a/src/main/java/com/openshift/jenkins/plugins/pipeline/OpenShiftImageTagger.java
+++ b/src/main/java/com/openshift/jenkins/plugins/pipeline/OpenShiftImageTagger.java
@@ -11,12 +11,12 @@ import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.QueryParameter;
 
 import com.openshift.jenkins.plugins.pipeline.model.IOpenShiftImageTagger;
-import com.openshift.restclient.authorization.TokenAuthorizationStrategy;
+//import com.openshift.restclient.authorization.TokenAuthorizationStrategy;
 
 import javax.servlet.ServletException;
 
 import java.io.IOException;
-import java.util.Map;
+//import java.util.Map;
 
 public class OpenShiftImageTagger extends OpenShiftBaseStep implements IOpenShiftImageTagger {
 
@@ -29,7 +29,7 @@ public class OpenShiftImageTagger extends OpenShiftBaseStep implements IOpenShif
     protected final String destinationAuthToken;
     protected final String alias;
     // marked transient so don't serialize these next 2 in the workflow plugin flow; constructed on per request basis
-    protected transient TokenAuthorizationStrategy destinationBearerToken;
+//    protected transient TokenAuthorizationStrategy destinationBearerToken;
     
     // Fields in config.jelly must match the parameter names in the "DataBoundConstructor"
     @DataBoundConstructor
@@ -77,14 +77,14 @@ public class OpenShiftImageTagger extends OpenShiftBaseStep implements IOpenShif
 		return this.destinationAuthToken;
 	}
 	
-	public TokenAuthorizationStrategy getDestinationToken() {
+/*	public TokenAuthorizationStrategy getDestinationToken() {
 		return destinationBearerToken;
 	}
 	
 	public void setDestinationToken(TokenAuthorizationStrategy token) {
 		destinationBearerToken = token;
 	}
-	
+*/	
 	
     // Overridden for better type safety.
     // If your plugin doesn't really define any property on Descriptor,

--- a/src/main/java/com/openshift/jenkins/plugins/pipeline/dsl/OpenShiftBaseStep.java
+++ b/src/main/java/com/openshift/jenkins/plugins/pipeline/dsl/OpenShiftBaseStep.java
@@ -8,7 +8,7 @@ import org.kohsuke.stapler.DataBoundSetter;
 
 import com.openshift.jenkins.plugins.pipeline.Auth;
 import com.openshift.jenkins.plugins.pipeline.model.IOpenShiftPlugin;
-import com.openshift.restclient.authorization.TokenAuthorizationStrategy;
+//import com.openshift.restclient.authorization.TokenAuthorizationStrategy;
 
 import jenkins.tasks.SimpleBuildStep;
 import hudson.FilePath;
@@ -25,7 +25,7 @@ public abstract class OpenShiftBaseStep extends AbstractStepImpl  implements Sim
     protected String authToken;
     protected String verbose;
     // marked transient so don't serialize these next 2 in the workflow plugin flow; constructed on per request basis
-    protected transient TokenAuthorizationStrategy bearerToken;
+    //protected transient TokenAuthorizationStrategy bearerToken;
     protected transient Auth auth;
     
     protected OpenShiftBaseStep() {
@@ -78,7 +78,7 @@ public abstract class OpenShiftBaseStep extends AbstractStepImpl  implements Sim
 		return auth;
 	}
 
-	@Override
+/*	@Override
 	public TokenAuthorizationStrategy getToken() {
 		return bearerToken;
 	}
@@ -87,7 +87,7 @@ public abstract class OpenShiftBaseStep extends AbstractStepImpl  implements Sim
 	public void setToken(TokenAuthorizationStrategy token) {
 		this.bearerToken = token;
 	}
-
+*/
 	@Override
 	public String getBaseClassName() {
 		return OpenShiftBaseStep.class.getName();

--- a/src/main/java/com/openshift/jenkins/plugins/pipeline/dsl/OpenShiftImageTagger.java
+++ b/src/main/java/com/openshift/jenkins/plugins/pipeline/dsl/OpenShiftImageTagger.java
@@ -13,7 +13,7 @@ import org.kohsuke.stapler.DataBoundSetter;
 
 import com.openshift.jenkins.plugins.pipeline.ParamVerify;
 import com.openshift.jenkins.plugins.pipeline.model.IOpenShiftImageTagger;
-import com.openshift.restclient.authorization.TokenAuthorizationStrategy;
+//import com.openshift.restclient.authorization.TokenAuthorizationStrategy;
 
 import java.util.Collection;
 import java.util.Map;
@@ -31,7 +31,7 @@ public class OpenShiftImageTagger extends OpenShiftBaseStep implements IOpenShif
     protected String destinationAuthToken;
     protected String alias;
     // marked transient so don't serialize these next 2 in the workflow plugin flow; constructed on per request basis
-    protected transient TokenAuthorizationStrategy destinationBearerToken;
+    //protected transient TokenAuthorizationStrategy destinationBearerToken;
     
     // Fields in config.jelly must match the parameter names in the "DataBoundConstructor"
     @DataBoundConstructor
@@ -107,14 +107,14 @@ public class OpenShiftImageTagger extends OpenShiftBaseStep implements IOpenShif
 		this.destinationAuthToken = destinationAuthToken;
 	}
 	
-	public TokenAuthorizationStrategy getDestinationToken() {
+/*	public TokenAuthorizationStrategy getDestinationToken() {
 		return destinationBearerToken;
 	}
 	
 	public void setDestinationToken(TokenAuthorizationStrategy token) {
 		destinationBearerToken = token;
 	}
-	
+*/	
 	
 	
     private static final Logger LOGGER = Logger.getLogger(OpenShiftImageTagger.class.getName());

--- a/src/main/java/com/openshift/jenkins/plugins/pipeline/model/IOpenShiftApiObjHandler.java
+++ b/src/main/java/com/openshift/jenkins/plugins/pipeline/model/IOpenShiftApiObjHandler.java
@@ -2,9 +2,6 @@ package com.openshift.jenkins.plugins.pipeline.model;
 
 import hudson.model.TaskListener;
 
-import java.io.IOException;
-import java.net.MalformedURLException;
-import java.net.URL;
 import java.util.List;
 import java.util.Map;
 
@@ -13,8 +10,6 @@ import net.sf.json.JSONObject;
 import org.jboss.dmr.ModelNode;
 import org.yaml.snakeyaml.Yaml;
 
-import com.openshift.internal.restclient.http.UrlConnectionHttpClient;
-import com.openshift.jenkins.plugins.pipeline.Auth;
 import com.openshift.jenkins.plugins.pipeline.MessageConstants;
 import com.openshift.jenkins.plugins.pipeline.OpenShiftApiObjHandler;
 import com.openshift.restclient.IClient;
@@ -22,30 +17,10 @@ import com.openshift.restclient.model.IResource;
 
 
 public interface IOpenShiftApiObjHandler extends IOpenShiftPlugin {
-
-    default UrlConnectionHttpClient createHttpClient() {
-		UrlConnectionHttpClient urlClient = new UrlConnectionHttpClient(
-				null, "application/json", null, getAuth(), null, null);
-		urlClient.setAuthorizationStrategy(getToken());
-		return urlClient;
-    }
-    
+	
 	default String fetchApiJsonFromApiServer(boolean chatty, TaskListener listener, 
     		Map<String,String> overrides, String apiDomain) {
-    	URL url = null;
-    	try {
-    		url = new URL(this.getApiURL(overrides) + "/swaggerapi/" + apiDomain + "/v1");
-		} catch (MalformedURLException e) {
-			e.printStackTrace(listener.getLogger());
-			return null;
-		}
-    	try {
-    		return createHttpClient().get(url, 10 * 1000);
-		} catch (IOException e1) {
-			if (chatty)
-				e1.printStackTrace(listener.getLogger());
-			return null;
-		}
+		return httpGet(chatty, listener, overrides, this.getApiURL(overrides) + "/swaggerapi/" + apiDomain + "/v1");
     }
     
     default void importJsonOfApiTypes(boolean chatty, TaskListener listener, 
@@ -68,7 +43,7 @@ public interface IOpenShiftApiObjHandler extends IOpenShiftPlugin {
         				String typeStrForURL = null;
         				String[] pathPieces = path.split("/");
         				for (String pathPiece : pathPieces) {
-        					if (pathPiece.equalsIgnoreCase(coreType + "s")) {
+        					if (pathPiece.equalsIgnoreCase(coreType + "s") || pathPiece.equalsIgnoreCase(coreType)) {
         						typeStrForURL = pathPiece;
         						break;
         					}
@@ -84,13 +59,12 @@ public interface IOpenShiftApiObjHandler extends IOpenShiftPlugin {
     	
     }
     
+	//TODO openshift-restclient-java's IApiTypeMapper is not really accessible from our perspective,
+	//without accessing/recreating the underlying OkHttpClient, so until that changes, we use our own
+	// type mapping
     default void updateApiTypes(boolean chatty, TaskListener listener, Map<String,String>overrides) {
-    	// our lower level openshift-restclient-java usage here is not agreeable with the TrustManager maintained there,
-    	// so we set up our own trust manager like we used to do in order to verify the server cert
-    	Auth.createLocalTrustStore(getAuth(), getApiURL(overrides));
 		importJsonOfApiTypes(chatty, listener, overrides, OpenShiftApiObjHandler.oapi, fetchApiJsonFromApiServer(chatty, listener, overrides, OpenShiftApiObjHandler.oapi));
 		importJsonOfApiTypes(chatty, listener, overrides, OpenShiftApiObjHandler.api, fetchApiJsonFromApiServer(chatty, listener, overrides, OpenShiftApiObjHandler.api));
-    	
     }
     
     default ModelNode hydrateJsonYaml(String jsonyaml, TaskListener listener) {

--- a/src/main/java/com/openshift/jenkins/plugins/pipeline/model/IOpenShiftImageTagger.java
+++ b/src/main/java/com/openshift/jenkins/plugins/pipeline/model/IOpenShiftImageTagger.java
@@ -18,7 +18,7 @@ import com.openshift.jenkins.plugins.pipeline.MessageConstants;
 import com.openshift.jenkins.plugins.pipeline.OpenShiftCreator;
 import com.openshift.restclient.IClient;
 import com.openshift.restclient.ResourceKind;
-import com.openshift.restclient.authorization.TokenAuthorizationStrategy;
+//import com.openshift.restclient.authorization.TokenAuthorizationStrategy;
 import com.openshift.restclient.model.IImageStream;
 
 public interface IOpenShiftImageTagger extends IOpenShiftPlugin {
@@ -43,10 +43,10 @@ public interface IOpenShiftImageTagger extends IOpenShiftPlugin {
 		
 	public String getDestinationAuthToken();
 		
-	public TokenAuthorizationStrategy getDestinationToken();
+/*	public TokenAuthorizationStrategy getDestinationToken();
 	
 	public void setDestinationToken(TokenAuthorizationStrategy token);
-	
+*/	
 	default String getAlias(Map<String,String> overrides) {
 		return getOverride(getAlias(), overrides);
 	}
@@ -138,7 +138,7 @@ public interface IOpenShiftImageTagger extends IOpenShiftPlugin {
     	
     	// get oc clients 
     	IClient client = this.getClient(listener, DISPLAY_NAME, overrides);
-   		setDestinationToken(new TokenAuthorizationStrategy(Auth.deriveBearerToken(null, getDestinationAuthToken(overrides), listener, chatty)));
+   		//setDestinationToken(new TokenAuthorizationStrategy(Auth.deriveBearerToken(null, getDestinationAuthToken(overrides), listener, chatty)));
     	
     	if (client != null) {
     		// get src id
@@ -200,8 +200,8 @@ public interface IOpenShiftImageTagger extends IOpenShiftPlugin {
     				// for the OpenShiftCreator
     				if (this.getDestinationAuthToken(overrides) != null && this.getDestinationAuthToken(overrides).length() > 0) {
     					this.setAuth(Auth.createInstance(chatty ? listener : null, getApiURL(overrides), overrides));
-    					this.setToken(getDestinationToken());
-    					client = this.getClient(listener, DISPLAY_NAME, overrides);
+    					//this.setToken(getDestinationToken());
+    					client = this.getClient(listener, DISPLAY_NAME, overrides, getDestinationAuthToken(overrides));
     				}
     				destIS = client.get(ResourceKind.IMAGE_STREAM, getProdStream(overrides), destinationNS);
     			} catch (com.openshift.restclient.OpenShiftException e) {
@@ -211,9 +211,9 @@ public interface IOpenShiftImageTagger extends IOpenShiftPlugin {
     				Map<String,String> newOverrides = new HashMap<String,String>(overrides);
     				// we don't want this step's source namespace to be the creator's namespace, but rather this step's destination namespace, so clear out the override and then reuse all other overrides
     				newOverrides.remove("namespace");
-    				OpenShiftCreator isCreator = new OpenShiftCreator(getApiURL(newOverrides), destinationNS, getDestinationToken().getToken(), getVerbose(newOverrides), createJson);
+    				OpenShiftCreator isCreator = new OpenShiftCreator(getApiURL(newOverrides), destinationNS, getDestinationAuthToken(overrides), getVerbose(newOverrides), createJson);
     				isCreator.setAuth(Auth.createInstance(chatty ? listener : null, getApiURL(newOverrides), overrides));
-    		    	isCreator.setToken(getDestinationToken());
+    		    	//isCreator.setToken(getDestinationToken());
     				
     				
     				boolean newISCreated = isCreator.coreLogic(launcher, listener, newOverrides);


### PR DESCRIPTION
…ng rework for create resources and dump logs; add cause to build request; switch to rest client pod logger for build logs (pod logger no longer dependent on oc binary)
