### PR TITLE
Resolve #66 duplication in Jenkins console output

### DIFF
--- a/src/main/java/com/openshift/jenkins/plugins/pipeline/model/IOpenShiftBuilder.java
+++ b/src/main/java/com/openshift/jenkins/plugins/pipeline/model/IOpenShiftBuilder.java
@@ -107,7 +107,7 @@ public interface IOpenShiftBuilder extends IOpenShiftPlugin {
 			if (Boolean.parseBoolean(getVerbose(overrides)))
 				listener.getLogger().println("\nOpenShiftBuilder bld state:  " + bldState);
 			
-			if (follow) {
+			if (follow && bldState.equals("Running") && stop == null) {
 				final String container = pod.getContainers().iterator().next().getName();
 				stop = pod.accept(new CapabilityVisitor<IPodLogRetrievalAsync, IStoppable>() {
 


### PR DESCRIPTION
Don't recreate pod listeners multiple times - do it once when the build status gets to Running

fixes https://github.com/openshift/jenkins-plugin/issues/66
