### PR TITLE
Adding environment variable support to build request

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,143 +101,136 @@ Here is the complete DSL reference for the OpenShift Pipeline Plugin.
 
 ####  Optional parameters that apply to all the DSL steps:
 
-a) "apiURL":  URL of the OpenShift api endpoint.  If nothing is specified, the plugin will inspect the KUBERNETES_SERVICE_HOST environment variable. If that variable is not set, the plugin will attempt to connect to "https://openshift.default.svc.cluster.local".
-
-b) "namespace":  The name of the project the BuildConfig is stored in.  If nothing is specified, the plugin will inspect the PROJECT_NAME environment variable.
-
-c) "authToken":  The authorization token for interacting with OpenShift.  If you do not supply a value, the plugin will assume it is running in the OpenShift Jenkins image and attempt to load the kubernetes service account token stored in that image.
-
-d) "verbose":  Allow for verbose logging during this build step plug-in.  Set to `true` to generate the additional logging.
+- "apiURL":  URL of the OpenShift api endpoint.  If nothing is specified, the plugin will inspect the KUBERNETES_SERVICE_HOST environment variable. If that variable is not set, the plugin will attempt to connect to "https://openshift.default.svc.cluster.local".
+- "namespace":  The name of the project the BuildConfig is stored in.  If nothing is specified, the plugin will inspect the PROJECT_NAME environment variable.
+- "authToken":  The authorization token for interacting with OpenShift.  If you do not supply a value, the plugin will assume it is running in the OpenShift Jenkins image and attempt to load the kubernetes service account token stored in that image.
+- "verbose":  Allow for verbose logging during this build step plug-in.  Set to `true` to generate the additional logging.
 
 ####  "Trigger OpenShift Build"
 
 The step name is "openshiftBuild".  Mandatory parameters are:
 
-a) "buildConfig" or "bldCfg":  The name of the BuildConfig to trigger
+- "buildConfig" or "bldCfg":  The name of the BuildConfig to trigger
 
 Optional parameters are:
 
-a) "buildName":  The name of a previous build which should be re-run.  Equivalent to specifying the `--from-build` option when invoking the OpenShift `oc start-build` command.
-
-b) "commitID":  The commit hash the build should be run from.  Equivalent to specifying the `--commit` option when invoking the OpenShift `oc start-build` command.
-
-c) "showBuildLogs":  Pipe the build logs from OpenShift to the Jenkins console.  
-
-d) "checkForTriggeredDeployments":  Verify whether any deployments triggered by this build's output fired.  
-
-e) "waitTime":  Time in milliseconds to wait for build completion.  Default is 5 minutes.
+- "buildName":  The name of a previous build which should be re-run.  Equivalent to specifying the `--from-build` option when invoking the OpenShift `oc start-build` command.
+- "commitID":  The commit hash the build should be run from.  Equivalent to specifying the `--commit` option when invoking the OpenShift `oc start-build` command.
+- "env": An array of environment variables for the build (e.g. `env : [ [ name : 'name1', value : 'value1' ], [ name : 'name2', value : 'value2' ] ]`.
+- "showBuildLogs":  Pipe the build logs from OpenShift to the Jenkins console.
+- "checkForTriggeredDeployments":  Verify whether any deployments triggered by this build's output fired.
+- "waitTime":  Time in milliseconds to wait for build completion.  Default is 5 minutes.
 
 #### "Trigger OpenShift Deployment"
 
 The step name is "openshiftDeploy".  Mandatory parameters are:
 
-a)  "deploymentConfig" or "depCfg":  The name of the DeploymentConfig to trigger.
+- "deploymentConfig" or "depCfg":  The name of the DeploymentConfig to trigger.
 
 Optional parameters are:
 
-a)  "waitTime":  Time in milliseconds to wait for deployment completion.  Default is 1 minute.
+-  "waitTime":  Time in milliseconds to wait for deployment completion.  Default is 1 minute.
 
 #### "Create OpenShift Resource(s)"
 
 The step name is "openshiftCreateResources".  Mandatory parameters is either:
 
-a) "json", "yaml", or "jsonyaml": The JSON or YAML representation of the OpenShift resources.  Note, the plugin does not care if YAML is provided under the "json" key or vice-versa.  As long
+- "json", "yaml", or "jsonyaml": The JSON or YAML representation of the OpenShift resources.  Note, the plugin does not care if YAML is provided under the "json" key or vice-versa.  As long
 as the string passes either the JSON or YAML format checking, it will be processed.
 
 #### "Delete OpenShift Resource(s) from JSON/YAML"
 
 The step name is "openshiftDeleteResourceByJsonYaml".  Mandatory parameters is either:
 
-a) "json", "yaml", or "jsonyaml": The JSON or YAML representation of the OpenShift resources.  Note, the plugin does not care if YAML is provided under the "json" key or vice-versa.  As long
+- "json", "yaml", or "jsonyaml": The JSON or YAML representation of the OpenShift resources.  Note, the plugin does not care if YAML is provided under the "json" key or vice-versa.  As long
 as the string passes either the JSON or YAML format checking, it will be processed.
 
 ####  "Delete OpenShift Resource(s) using Labels"
 
 The step name is "openshiftDeleteResourceByLabels".  Mandatory parameters are:
 
-a)  "types":  The type(s) of OpenShift resource(s) to delete.  Provide a comma-separated list.
+-  "types":  The type(s) of OpenShift resource(s) to delete.  Provide a comma-separated list.
 
-b)  "keys":  The key(s) of labels on the OpenShift resource(s) to delete.  Provide a comma-separated list.
+-  "keys":  The key(s) of labels on the OpenShift resource(s) to delete.  Provide a comma-separated list.
 
-c)  "values":  The value(s) of labels on the OpenShift resource(s) to delete.  Provide a comma-separated list.
+-  "values":  The value(s) of labels on the OpenShift resource(s) to delete.  Provide a comma-separated list.
 
 ####  "Delete OpenShift Resource(s) by Key"
 
 The step name is "openshiftDeleteResourceByKey".  Mandatory parameters are:
 
-a)  "types":  The type(s) of OpenShift resource(s) to delete.  Provide a comma-separated list.
+- "types":  The type(s) of OpenShift resource(s) to delete.  Provide a comma-separated list.
 
-b)  "keys":  The key(s) of the OpenShift resource(s) to delete.  Provide a comma-separated list.
+- "keys":  The key(s) of the OpenShift resource(s) to delete.  Provide a comma-separated list.
 
 ####  "Scale OpenShift Deployment"
 
 The step name is "openshiftScale".  Mandatory parameters are:
 
-a)  "deploymentConfig" or "depCfg":  The name of the DeploymentConfig to scale.
+- "deploymentConfig" or "depCfg":  The name of the DeploymentConfig to scale.
 
-b)  "replicaCount":  The number of replicas to scale to.
+- "replicaCount":  The number of replicas to scale to.
 
 Optional parameters are:
 
-a)  "verifyReplicaCount":  Verify whether the specified number of replicas are up.  Specify `true` or `false`.
+- "verifyReplicaCount":  Verify whether the specified number of replicas are up.  Specify `true` or `false`.
 
-b)  "waitTime":  The amount of time in milliseconds to see whether the specified number of replicas have been reached.  Default is 3 minutes.
+- "waitTime":  The amount of time in milliseconds to see whether the specified number of replicas have been reached.  Default is 3 minutes.
 
 ####  "Tag OpenShift Image"
 
 The step name is "openshiftTag".  Mandatory parameters are:
 
-a)  "sourceStream" or "srcStream":  The ImageStream of the existing image.
+- "sourceStream" or "srcStream":  The ImageStream of the existing image.
 
-b)  "sourceTag" or "srcTag":  The tag (ImageStreamTag type) or ID (ImageStreamImage type) of the existing image. 
+- "sourceTag" or "srcTag":  The tag (ImageStreamTag type) or ID (ImageStreamImage type) of the existing image.
 
-c)  "destinationStream" or "destStream":  The ImageStream for the new tag.
+- "destinationStream" or "destStream":  The ImageStream for the new tag.
 
-d)  "destinationTag" or "destTag":  The name of the new tag.
+- "destinationTag" or "destTag":  The name of the new tag.
 
 Optional parameters are:
 
-a)  "alias":  Whether to update destination tag whenever the source tag changes.  Equivalent of the `--alias` option for the `oc tag` command. When false, the destination tag type is "ImageStreamImage", and when true, the destination tag type is "ImageStreamTag".
+- "alias":  Whether to update destination tag whenever the source tag changes.  Equivalent of the `--alias` option for the `oc tag` command. When false, the destination tag type is "ImageStreamImage", and when true, the destination tag type is "ImageStreamTag".
 
-b)  "destinationNamespace":  The name of the project to host the destinationStream:destinationTag.  If nothing is specified, the plugin will inspect the PROJECT_NAME environment variable.
+- "destinationNamespace":  The name of the project to host the destinationStream:destinationTag.  If nothing is specified, the plugin will inspect the PROJECT_NAME environment variable.
 
-c)  "destinationAuthToken":  The authorization token for interacting with the destinationNamespace.  If you do not supply a value, the plugin will assume it is running in the OpenShift Jenkins image and attempt to load the kubernetes service account token stored in that image.
+- "destinationAuthToken":  The authorization token for interacting with the destinationNamespace.  If you do not supply a value, the plugin will assume it is running in the OpenShift Jenkins image and attempt to load the kubernetes service account token stored in that image.
 
 ####  "Verify OpenShift Build"
 
 The step name is "openshiftVerifyBuild".  Mandatory parameters are:
 
-a)  "buildConfig" or "bldCfg":  The name of the BuildConfig to verify.
+- "buildConfig" or "bldCfg":  The name of the BuildConfig to verify.
 
 Optional parameters are:
 
-a) "checkForTriggeredDeployments":  Verify whether any deployments triggered by this build's output fired.  
-
-b) "waitTime":  Time in milliseconds to wait for build completion.  Default is 1 minute.
+- "checkForTriggeredDeployments":  Verify whether any deployments triggered by this build's output fired.
+- "waitTime":  Time in milliseconds to wait for build completion.  Default is 1 minute.
 
 #### "Verify OpenShift Deployment"
 
 The step name is "openshiftVerifyDeployment".  Mandatory parameters are:
 
-a)  "deploymentConfig" or "depCfg":  The name of the DeploymentConfig to scale.
+-  "deploymentConfig" or "depCfg":  The name of the DeploymentConfig to scale.
 
 Optional parameters are:
 
-a)  "replicaCount":  The number of replicas to scale to.
+- "replicaCount":  The number of replicas to scale to.
 
-b)  "verifyReplicaCount":  Verify whether the specified number of replicas are up.  Specify `true` or `false`.
+- "verifyReplicaCount":  Verify whether the specified number of replicas are up.  Specify `true` or `false`.
 
-c)  "waitTime":  The amount of time in milliseconds to see whether the specified number of replicas have been reached.  Default is 1 minute.
+- "waitTime":  The amount of time in milliseconds to see whether the specified number of replicas have been reached.  Default is 1 minute.
 
 ####  "Verify OpenShift Service"
 
 The step name is "openshiftVerifyService".  Mandatory parameters are:
 
-a)  "serviceName" or "svcName":  The name of the service to connect to.
+- "serviceName" or "svcName":  The name of the service to connect to.
 
 Optional parameters are:
 
-a)  "retryCount":  The number of times to attempt a connection before giving up.  The default is 100.
+- "retryCount":  The number of times to attempt a connection before giving up.  The default is 100.
 
 
 ### Pipeline / Workflow support prior to version 1.0.14 of the OpenShift Pipeline Plugin 

--- a/pom.xml
+++ b/pom.xml
@@ -77,11 +77,12 @@
 			<groupId>org.jboss</groupId>
 			<artifactId>jboss-dmr</artifactId>
 			<version>1.3.0.Final</version>
-		</dependency>
+	</dependency>
+
 	<dependency>
 	    <groupId>com.openshift</groupId>
 	    <artifactId>openshift-restclient-java</artifactId>
-	    <version>5.0.0-SNAPSHOT</version>
+	    <version>5.2.0-SNAPSHOT</version>
 	</dependency>
     
   	<dependency>

--- a/src/main/java/com/openshift/jenkins/plugins/pipeline/NameValuePair.java
+++ b/src/main/java/com/openshift/jenkins/plugins/pipeline/NameValuePair.java
@@ -1,0 +1,40 @@
+package com.openshift.jenkins.plugins.pipeline;
+
+import hudson.Extension;
+import hudson.model.AbstractDescribableImpl;
+import hudson.model.Descriptor;
+import hudson.util.FormValidation;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.QueryParameter;
+
+public class NameValuePair extends AbstractDescribableImpl<NameValuePair> {
+
+    protected final String name;
+    protected final String value;
+
+    @DataBoundConstructor
+    public NameValuePair(String name, String value) {
+        this.name = name;
+        this.value = value;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    @Extension
+    public static class DescriptorImpl extends Descriptor<NameValuePair> {
+        public String getDisplayName() {
+            return "Name/Value Pair";
+        }
+
+        public FormValidation doCheckName(@QueryParameter String value) {
+            return FormValidation.validateRequired(value);
+        }
+    }
+
+}

--- a/src/main/java/com/openshift/jenkins/plugins/pipeline/OpenShiftBasePostAction.java
+++ b/src/main/java/com/openshift/jenkins/plugins/pipeline/OpenShiftBasePostAction.java
@@ -34,7 +34,7 @@ public abstract class OpenShiftBasePostAction extends Recorder implements Simple
 
     // generically speaking, Jenkins will always pass in non-null field values.  However, as we have periodically
     // added new fields, jobs created with earlier versions of the plugin get null for the new fields.  Hence, 
-    // we have introduced the generic convention (even for fields that existed in the intial incarnations of the plugin)
+    // we have introduced the generic convention (even for fields that existed in the initial incarnations of the plugin)
     // of insuring nulls are not returned for field getters
 
     public String getApiURL() {

--- a/src/main/java/com/openshift/jenkins/plugins/pipeline/OpenShiftBaseStep.java
+++ b/src/main/java/com/openshift/jenkins/plugins/pipeline/OpenShiftBaseStep.java
@@ -34,7 +34,7 @@ public abstract class OpenShiftBaseStep extends Builder  implements SimpleBuildS
 
     // generically speaking, Jenkins will always pass in non-null field values.  However, as we have periodically
     // added new fields, jobs created with earlier versions of the plugin get null for the new fields.  Hence, 
-    // we have introduced the generic convention (even for fields that existed in the intial incarnations of the plugin)
+    // we have introduced the generic convention (even for fields that existed in the initial incarnations of the plugin)
     // of insuring nulls are not returned for field getters
 
     public String getApiURL() {

--- a/src/main/java/com/openshift/jenkins/plugins/pipeline/OpenShiftBuildCanceller.java
+++ b/src/main/java/com/openshift/jenkins/plugins/pipeline/OpenShiftBuildCanceller.java
@@ -44,7 +44,7 @@ public class OpenShiftBuildCanceller extends OpenShiftBasePostAction {
 
     // generically speaking, Jenkins will always pass in non-null field values.  However, as we have periodically
     // added new fields, jobs created with earlier versions of the plugin get null for the new fields.  Hence, 
-    // we have introduced the generic convention (even for fields that existed in the intial incarnations of the plugin)
+    // we have introduced the generic convention (even for fields that existed in the initial incarnations of the plugin)
     // of insuring nulls are not returned for field getters
 
     public String getBldCfg() {

--- a/src/main/java/com/openshift/jenkins/plugins/pipeline/OpenShiftBuildVerifier.java
+++ b/src/main/java/com/openshift/jenkins/plugins/pipeline/OpenShiftBuildVerifier.java
@@ -35,7 +35,7 @@ public class OpenShiftBuildVerifier extends OpenShiftBaseStep implements IOpenSh
 
     // generically speaking, Jenkins will always pass in non-null field values.  However, as we have periodically
     // added new fields, jobs created with earlier versions of the plugin get null for the new fields.  Hence, 
-    // we have introduced the generic convention (even for fields that existed in the intial incarnations of the plugin)
+    // we have introduced the generic convention (even for fields that existed in the initial incarnations of the plugin)
     // of insuring nulls are not returned for field getters
 
 	public String getBldCfg() {

--- a/src/main/java/com/openshift/jenkins/plugins/pipeline/OpenShiftBuilder.java
+++ b/src/main/java/com/openshift/jenkins/plugins/pipeline/OpenShiftBuilder.java
@@ -1,22 +1,21 @@
 package com.openshift.jenkins.plugins.pipeline;
-import java.io.IOException;
-import java.util.Map;
-
-import javax.servlet.ServletException;
-
-import org.kohsuke.stapler.DataBoundConstructor;
-import org.kohsuke.stapler.QueryParameter;
-import org.kohsuke.stapler.StaplerRequest;
 
 import com.openshift.jenkins.plugins.pipeline.model.GlobalConfig;
 import com.openshift.jenkins.plugins.pipeline.model.IOpenShiftBuilder;
-
 import hudson.Extension;
 import hudson.model.AbstractProject;
 import hudson.tasks.BuildStepDescriptor;
 import hudson.tasks.Builder;
 import hudson.util.FormValidation;
 import net.sf.json.JSONObject;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.QueryParameter;
+import org.kohsuke.stapler.StaplerRequest;
+
+import javax.servlet.ServletException;
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
 
 
 public class OpenShiftBuilder extends OpenShiftBaseStep implements IOpenShiftBuilder {
@@ -27,13 +26,15 @@ public class OpenShiftBuilder extends OpenShiftBaseStep implements IOpenShiftBui
     protected final String showBuildLogs;
     protected final String checkForTriggeredDeployments;
     protected final String waitTime;
+    protected final List<NameValuePair> envVars;
     
-    
+
     // Fields in config.jelly must match the parameter names in the "DataBoundConstructor"
     @DataBoundConstructor
-    public OpenShiftBuilder(String apiURL, String bldCfg, String namespace, String authToken, String verbose, String commitID, String buildName, String showBuildLogs, String checkForTriggeredDeployments, String waitTime) {
+    public OpenShiftBuilder(String apiURL, String bldCfg, String namespace, List<NameValuePair> env, String authToken, String verbose, String commitID, String buildName, String showBuildLogs, String checkForTriggeredDeployments, String waitTime) {
     	super(apiURL, namespace, authToken, verbose);
         this.bldCfg = bldCfg;
+        this.envVars = env;
         this.commitID = commitID;
         this.buildName = buildName;
         this.showBuildLogs = showBuildLogs;
@@ -43,7 +44,7 @@ public class OpenShiftBuilder extends OpenShiftBaseStep implements IOpenShiftBui
 
     // generically speaking, Jenkins will always pass in non-null field values.  However, as we have periodically
     // added new fields, jobs created with earlier versions of the plugin get null for the new fields.  Hence, 
-    // we have introduced the generic convention (even for fields that existed in the intial incarnations of the plugin)
+    // we have introduced the generic convention (even for fields that existed in the initial incarnations of the plugin)
     // of insuring nulls are not returned for field getters
 
 	public String getCommitID() {
@@ -61,6 +62,10 @@ public class OpenShiftBuilder extends OpenShiftBaseStep implements IOpenShiftBui
 	public String getBldCfg() {
 		return bldCfg;
 	}
+
+    public List<NameValuePair>  getEnv() {
+        return envVars;
+    }
 	
 	public String getCheckForTriggeredDeployments() {
 		return checkForTriggeredDeployments;

--- a/src/main/java/com/openshift/jenkins/plugins/pipeline/OpenShiftCreator.java
+++ b/src/main/java/com/openshift/jenkins/plugins/pipeline/OpenShiftCreator.java
@@ -30,7 +30,7 @@ public class OpenShiftCreator extends OpenShiftBaseStep implements IOpenShiftCre
 
     // generically speaking, Jenkins will always pass in non-null field values.  However, as we have periodically
     // added new fields, jobs created with earlier versions of the plugin get null for the new fields.  Hence, 
-    // we have introduced the generic convention (even for fields that existed in the intial incarnations of the plugin)
+    // we have introduced the generic convention (even for fields that existed in the initial incarnations of the plugin)
     // of insuring nulls are not returned for field getters
 
     public String getJsonyaml() {

--- a/src/main/java/com/openshift/jenkins/plugins/pipeline/OpenShiftDeleterJsonYaml.java
+++ b/src/main/java/com/openshift/jenkins/plugins/pipeline/OpenShiftDeleterJsonYaml.java
@@ -30,7 +30,7 @@ public class OpenShiftDeleterJsonYaml extends OpenShiftBaseStep implements IOpen
 
     // generically speaking, Jenkins will always pass in non-null field values.  However, as we have periodically
     // added new fields, jobs created with earlier versions of the plugin get null for the new fields.  Hence, 
-    // we have introduced the generic convention (even for fields that existed in the intial incarnations of the plugin)
+    // we have introduced the generic convention (even for fields that existed in the initial incarnations of the plugin)
     // of insuring nulls are not returned for field getters
 
     public String getJsonyaml() {

--- a/src/main/java/com/openshift/jenkins/plugins/pipeline/OpenShiftDeleterLabels.java
+++ b/src/main/java/com/openshift/jenkins/plugins/pipeline/OpenShiftDeleterLabels.java
@@ -40,7 +40,7 @@ public class OpenShiftDeleterLabels extends OpenShiftBaseStep implements IOpenSh
 
     // generically speaking, Jenkins will always pass in non-null field values.  However, as we have periodically
     // added new fields, jobs created with earlier versions of the plugin get null for the new fields.  Hence, 
-    // we have introduced the generic convention (even for fields that existed in the intial incarnations of the plugin)
+    // we have introduced the generic convention (even for fields that existed in the initial incarnations of the plugin)
     // of insuring nulls are not returned for field getters
 	public String getTypes() {
 		return types;

--- a/src/main/java/com/openshift/jenkins/plugins/pipeline/OpenShiftDeleterList.java
+++ b/src/main/java/com/openshift/jenkins/plugins/pipeline/OpenShiftDeleterList.java
@@ -37,7 +37,7 @@ public class OpenShiftDeleterList extends OpenShiftBaseStep implements IOpenShif
 
     // generically speaking, Jenkins will always pass in non-null field values.  However, as we have periodically
     // added new fields, jobs created with earlier versions of the plugin get null for the new fields.  Hence, 
-    // we have introduced the generic convention (even for fields that existed in the intial incarnations of the plugin)
+    // we have introduced the generic convention (even for fields that existed in the initial incarnations of the plugin)
     // of insuring nulls are not returned for field getters
 	public String getTypes() {
 		return types;

--- a/src/main/java/com/openshift/jenkins/plugins/pipeline/OpenShiftDeployCanceller.java
+++ b/src/main/java/com/openshift/jenkins/plugins/pipeline/OpenShiftDeployCanceller.java
@@ -41,7 +41,7 @@ public class OpenShiftDeployCanceller extends OpenShiftBasePostAction {
 
     // generically speaking, Jenkins will always pass in non-null field values.  However, as we have periodically
     // added new fields, jobs created with earlier versions of the plugin get null for the new fields.  Hence, 
-    // we have introduced the generic convention (even for fields that existed in the intial incarnations of the plugin)
+    // we have introduced the generic convention (even for fields that existed in the initial incarnations of the plugin)
     // of insuring nulls are not returned for field getters
 
 	public String getDepCfg() {

--- a/src/main/java/com/openshift/jenkins/plugins/pipeline/OpenShiftDeployer.java
+++ b/src/main/java/com/openshift/jenkins/plugins/pipeline/OpenShiftDeployer.java
@@ -36,7 +36,7 @@ public class OpenShiftDeployer extends OpenShiftBaseStep implements IOpenShiftDe
 
     // generically speaking, Jenkins will always pass in non-null field values.  However, as we have periodically
     // added new fields, jobs created with earlier versions of the plugin get null for the new fields.  Hence, 
-    // we have introduced the generic convention (even for fields that existed in the intial incarnations of the plugin)
+    // we have introduced the generic convention (even for fields that existed in the initial incarnations of the plugin)
     // of insuring nulls are not returned for field getters
 
 	public String getDepCfg() {

--- a/src/main/java/com/openshift/jenkins/plugins/pipeline/OpenShiftDeploymentVerifier.java
+++ b/src/main/java/com/openshift/jenkins/plugins/pipeline/OpenShiftDeploymentVerifier.java
@@ -38,7 +38,7 @@ public class OpenShiftDeploymentVerifier extends OpenShiftBaseStep implements IO
 
     // generically speaking, Jenkins will always pass in non-null field values.  However, as we have periodically
     // added new fields, jobs created with earlier versions of the plugin get null for the new fields.  Hence, 
-    // we have introduced the generic convention (even for fields that existed in the intial incarnations of the plugin)
+    // we have introduced the generic convention (even for fields that existed in the initial incarnations of the plugin)
     // of insuring nulls are not returned for field getters
 
 	public String getDepCfg() {

--- a/src/main/java/com/openshift/jenkins/plugins/pipeline/OpenShiftImageStreams.java
+++ b/src/main/java/com/openshift/jenkins/plugins/pipeline/OpenShiftImageStreams.java
@@ -65,7 +65,7 @@ public class OpenShiftImageStreams extends SCM implements IOpenShiftPlugin {
 
     // generically speaking, Jenkins will always pass in non-null field values.  However, as we have periodically
     // added new fields, jobs created with earlier versions of the plugin get null for the new fields.  Hence, 
-    // we have introduced the generic convention (even for fields that existed in the intial incarnations of the plugin)
+    // we have introduced the generic convention (even for fields that existed in the initial incarnations of the plugin)
     // of insuring nulls are not returned for field getters
 
 	public String getApiURL() {

--- a/src/main/java/com/openshift/jenkins/plugins/pipeline/OpenShiftImageTagger.java
+++ b/src/main/java/com/openshift/jenkins/plugins/pipeline/OpenShiftImageTagger.java
@@ -47,7 +47,7 @@ public class OpenShiftImageTagger extends OpenShiftBaseStep implements IOpenShif
 
     // generically speaking, Jenkins will always pass in non-null field values.  However, as we have periodically
     // added new fields, jobs created with earlier versions of the plugin get null for the new fields.  Hence, 
-    // we have introduced the generic convention (even for fields that existed in the intial incarnations of the plugin)
+    // we have introduced the generic convention (even for fields that existed in the initial incarnations of the plugin)
     // of insuring nulls are not returned for field getters
 
 	public String getAlias() {

--- a/src/main/java/com/openshift/jenkins/plugins/pipeline/OpenShiftScaler.java
+++ b/src/main/java/com/openshift/jenkins/plugins/pipeline/OpenShiftScaler.java
@@ -37,7 +37,7 @@ public class OpenShiftScaler extends OpenShiftBaseStep implements IOpenShiftScal
 
     // generically speaking, Jenkins will always pass in non-null field values.  However, as we have periodically
     // added new fields, jobs created with earlier versions of the plugin get null for the new fields.  Hence, 
-    // we have introduced the generic convention (even for fields that existed in the intial incarnations of the plugin)
+    // we have introduced the generic convention (even for fields that existed in the initial incarnations of the plugin)
     // of insuring nulls are not returned for field getters
 
 	public String getDepCfg() {

--- a/src/main/java/com/openshift/jenkins/plugins/pipeline/OpenShiftScalerPostAction.java
+++ b/src/main/java/com/openshift/jenkins/plugins/pipeline/OpenShiftScalerPostAction.java
@@ -37,7 +37,7 @@ public class OpenShiftScalerPostAction extends OpenShiftBasePostAction implement
 
     // generically speaking, Jenkins will always pass in non-null field values.  However, as we have periodically
     // added new fields, jobs created with earlier versions of the plugin get null for the new fields.  Hence, 
-    // we have introduced the generic convention (even for fields that existed in the intial incarnations of the plugin)
+    // we have introduced the generic convention (even for fields that existed in the initial incarnations of the plugin)
     // of insuring nulls are not returned for field getters
 
 	public String getDepCfg() {

--- a/src/main/java/com/openshift/jenkins/plugins/pipeline/OpenShiftServiceVerifier.java
+++ b/src/main/java/com/openshift/jenkins/plugins/pipeline/OpenShiftServiceVerifier.java
@@ -33,7 +33,7 @@ public class OpenShiftServiceVerifier extends OpenShiftBaseStep implements IOpen
 
     // generically speaking, Jenkins will always pass in non-null field values.  However, as we have periodically
     // added new fields, jobs created with earlier versions of the plugin get null for the new fields.  Hence, 
-    // we have introduced the generic convention (even for fields that existed in the intial incarnations of the plugin)
+    // we have introduced the generic convention (even for fields that existed in the initial incarnations of the plugin)
     // of insuring nulls are not returned for field getters
 
 	public String getSvcName() {

--- a/src/main/java/com/openshift/jenkins/plugins/pipeline/dsl/OpenShiftBaseStep.java
+++ b/src/main/java/com/openshift/jenkins/plugins/pipeline/dsl/OpenShiftBaseStep.java
@@ -33,7 +33,7 @@ public abstract class OpenShiftBaseStep extends AbstractStepImpl  implements Sim
 
     // generically speaking, Jenkins will always pass in non-null field values.  However, as we have periodically
     // added new fields, jobs created with earlier versions of the plugin get null for the new fields.  Hence, 
-    // we have introduced the generic convention (even for fields that existed in the intial incarnations of the plugin)
+    // we have introduced the generic convention (even for fields that existed in the initial incarnations of the plugin)
     // of insuring nulls are not returned for field getters
 
     public String getApiURL() {

--- a/src/main/java/com/openshift/jenkins/plugins/pipeline/dsl/OpenShiftImageTagger.java
+++ b/src/main/java/com/openshift/jenkins/plugins/pipeline/dsl/OpenShiftImageTagger.java
@@ -44,7 +44,7 @@ public class OpenShiftImageTagger extends OpenShiftBaseStep implements IOpenShif
 
     // generically speaking, Jenkins will always pass in non-null field values.  However, as we have periodically
     // added new fields, jobs created with earlier versions of the plugin get null for the new fields.  Hence, 
-    // we have introduced the generic convention (even for fields that existed in the intial incarnations of the plugin)
+    // we have introduced the generic convention (even for fields that existed in the initial incarnations of the plugin)
     // of insuring nulls are not returned for field getters
 
 	public String getAlias() {

--- a/src/main/resources/com/openshift/jenkins/plugins/pipeline/NameValuePair/config.jelly
+++ b/src/main/resources/com/openshift/jenkins/plugins/pipeline/NameValuePair/config.jelly
@@ -1,0 +1,14 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+  <f:entry title="Name" field="name">
+    <f:textbox  />
+  </f:entry>
+  <f:entry title="Value" field="value">
+    <f:textbox  />
+  </f:entry>
+  <f:entry>
+    <div align="right">
+      <f:repeatableDeleteButton/>
+    </div>
+  </f:entry>
+</j:jelly>

--- a/src/main/resources/com/openshift/jenkins/plugins/pipeline/NameValuePair/global.jelly
+++ b/src/main/resources/com/openshift/jenkins/plugins/pipeline/NameValuePair/global.jelly
@@ -1,0 +1,15 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+  <!--
+    This Jelly script is used to produce the global configuration option.
+
+    Jenkins uses a set of tag libraries to provide uniformity in forms.
+    To determine where this tag is defined, first check the namespace URI,
+    and then look under $JENKINS/views/. For example, <f:section> is defined
+    in $JENKINS/views/lib/form/section.jelly.
+
+    It's also often useful to just check other similar scripts to see what
+    tags they use. Views are always organized according to its owner class,
+    so it should be straightforward to find them.
+  -->
+</j:jelly>

--- a/src/main/resources/com/openshift/jenkins/plugins/pipeline/NameValuePair/help-name.html
+++ b/src/main/resources/com/openshift/jenkins/plugins/pipeline/NameValuePair/help-name.html
@@ -1,0 +1,3 @@
+<div>
+  The name of the environment variable to set.
+</div>

--- a/src/main/resources/com/openshift/jenkins/plugins/pipeline/NameValuePair/help-value.html
+++ b/src/main/resources/com/openshift/jenkins/plugins/pipeline/NameValuePair/help-value.html
@@ -1,0 +1,3 @@
+<div>
+  The value for the environment variable.
+</div>

--- a/src/main/resources/com/openshift/jenkins/plugins/pipeline/OpenShiftBuilder/config.jelly
+++ b/src/main/resources/com/openshift/jenkins/plugins/pipeline/OpenShiftBuilder/config.jelly
@@ -25,6 +25,9 @@
   <f:entry title="Specify the commit hash the build should be run from" field="commitID">
     <f:textbox  />
   </f:entry>
+  <f:entry title="Specify environment variables for the build" field="env">
+    <f:repeatableProperty field="env"  minimum="0" />
+  </f:entry>
   <f:entry title="Allow for verbose logging during this build step plug-in" field="verbose">
     <f:booleanRadio default="false" />
   </f:entry>

--- a/src/main/resources/com/openshift/jenkins/plugins/pipeline/OpenShiftBuilder/help-env.html
+++ b/src/main/resources/com/openshift/jenkins/plugins/pipeline/OpenShiftBuilder/help-env.html
@@ -1,0 +1,3 @@
+<div>
+  Specify a list of environment variables to include in the build (see `oc start-build -e ...`).
+</div>

--- a/src/main/resources/com/openshift/jenkins/plugins/pipeline/dsl/OpenShiftBuilder/help-env.html
+++ b/src/main/resources/com/openshift/jenkins/plugins/pipeline/dsl/OpenShiftBuilder/help-env.html
@@ -1,0 +1,1 @@
+../../OpenShiftBuilder/help-env.html


### PR DESCRIPTION
In order to support environment variable feature request: https://trello.com/c/Yl4qomsw/878-5-additional-jenkins-plugin-enhancement-requests-from-github .

**Depends** on openshift/openshift-restclient-java#217

ptal @gabemontero @bparees 

Random changes:
- Global search and replace on "intial" misspell 
- Changed README.MD from using a) b) syntax to bullets to ease maintenance. 

DSL Syntax Example:
openshiftBuild( **env: [ test:'value', 'longenv1': 'env2']**, apiURL: 'https://10.13.137.85:8443' ....

Build Step Visualization:
![buildstep](https://cloud.githubusercontent.com/assets/19783215/18890433/1c3aedd4-84cf-11e6-9512-2ae50b2c5ba2.png)
