### PR TITLE
DSL step for ImageStreams SCM

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,6 +239,20 @@ Optional parameters are:
 
 a)  "retryCount":  The number of times to attempt a connection before giving up.  The default is 100.
 
+####  "ImageStreams SCM"
+
+This step associates a pipeline with an ImageStream as its SCM. With polling enabled on a job,
+this allows a pipeline job to be launched automatically whenever a new image is tagged on an 
+ImageStream.
+
+The step name is "openshiftImageStream". Mandatory parameters are:
+
+a) "name":  The name of the ImageStream to poll
+
+b) "tag":  The tag to watch on the ImageStream
+
+c) "namespace": The project for the ImageStream
+
 
 ### Pipeline / Workflow support prior to version 1.0.14 of the OpenShift Pipeline Plugin 
 

--- a/src/main/java/com/openshift/jenkins/plugins/pipeline/dsl/OpenShiftImageStreams.java
+++ b/src/main/java/com/openshift/jenkins/plugins/pipeline/dsl/OpenShiftImageStreams.java
@@ -1,0 +1,161 @@
+package com.openshift.jenkins.plugins.pipeline.dsl;
+
+import com.openshift.jenkins.plugins.pipeline.Auth;
+import com.openshift.jenkins.plugins.pipeline.ParamVerify;
+import hudson.Extension;
+import hudson.scm.SCM;
+import hudson.util.FormValidation;
+import org.jenkinsci.plugins.workflow.steps.scm.SCMStep;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
+import org.kohsuke.stapler.QueryParameter;
+
+import javax.annotation.Nonnull;
+import javax.servlet.ServletException;
+import java.io.IOException;
+
+/**
+ * SCMStep for OpenShiftImageStreams
+ */
+public class OpenShiftImageStreams extends SCMStep {
+
+
+    protected String name;
+    protected String tag;
+    protected String apiURL;
+    protected String namespace;
+    protected String authToken;
+    protected String verbose;
+
+    // marked transient so don't serialize; constructed on per request basis
+    protected transient Auth auth;
+
+    @DataBoundSetter
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    @DataBoundSetter
+    public void setTag(String tag) {
+        this.tag = tag;
+    }
+
+    @DataBoundSetter
+    public void setApiURL(String apiURL) {
+        this.apiURL = apiURL;
+    }
+
+    @DataBoundSetter
+    public void setNamespace(String namespace) {
+        this.namespace = namespace;
+    }
+
+    @DataBoundSetter
+    public void setAuthToken(String authToken) {
+        this.authToken = authToken;
+    }
+
+    @DataBoundSetter
+    public void setVerbose(String verbose) {
+        this.verbose = verbose;
+    }
+
+    public void setAuth(Auth auth) {
+        this.auth = auth;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getTag() {
+        return tag;
+    }
+
+    public String getApiURL() {
+        return apiURL;
+    }
+
+    public String getNamespace() {
+        return namespace;
+    }
+
+    public String getAuthToken() {
+        return authToken;
+    }
+
+    public String getVerbose() {
+        return verbose;
+    }
+
+    public Auth getAuth() {
+        return auth;
+    }
+
+    @DataBoundConstructor
+    public OpenShiftImageStreams (String name, String tag, String namespace) {
+        this.name = name;
+        this.tag = tag;
+        this.namespace = namespace;
+    }
+
+    @Nonnull
+    @Override
+    protected SCM createSCM() {
+        com.openshift.jenkins.plugins.pipeline.OpenShiftImageStreams scm = new com.openshift.jenkins.plugins.pipeline.OpenShiftImageStreams(
+                name,
+                tag,
+                apiURL,
+                namespace,
+                authToken,
+                verbose);
+        scm.setAuth(auth);
+        return scm;
+    }
+
+    @Extension(optional=true) public static final class DescriptorImpl extends SCMStepDescriptor {
+
+        public DescriptorImpl() {
+            // Fail now if dependency plugin not loaded. Descriptor.<init> will actually fail anyway, but this is just to be sure.
+            com.openshift.jenkins.plugins.pipeline.OpenShiftImageStreams.class.hashCode();
+        }
+
+        @Override
+        public String getFunctionName() {
+            return "openshiftImageStream";
+        }
+
+        @Override
+        public String getDisplayName() {
+            return "OpenShift ImageStreams";
+        }
+
+        public FormValidation doCheckApiURL(@QueryParameter String value)
+                throws IOException, ServletException {
+            // with some of the paths into the Image Stream SCM, the env vars typically available for the build steps are not available,
+            // but for now, we fall back on "https://openshift.default.svc.cluster.local" if they do not specify
+            return ParamVerify.doCheckApiURL(value);
+        }
+
+        public FormValidation doCheckNamespace(@QueryParameter String value)
+                throws IOException, ServletException {
+            // If a namespace is not specified, the default one is going to be used
+            return ParamVerify.doCheckNamespace(value);
+        }
+
+        public FormValidation doCheckTag(@QueryParameter String value)
+                throws IOException, ServletException {
+            return ParamVerify.doCheckTag(value);
+        }
+
+        public FormValidation doCheckName(@QueryParameter String value)
+                throws IOException, ServletException {
+            return ParamVerify.doCheckImageStreamName(value);
+        }
+
+        public FormValidation doCheckAuthToken(@QueryParameter String value)
+                throws IOException, ServletException {
+            return ParamVerify.doCheckToken(value);
+        }
+    }
+}

--- a/src/main/resources/com/openshift/jenkins/plugins/pipeline/dsl/OpenShiftImageStreams/config.jelly
+++ b/src/main/resources/com/openshift/jenkins/plugins/pipeline/dsl/OpenShiftImageStreams/config.jelly
@@ -1,0 +1,32 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+  <!--
+    This jelly script is used for per-project configuration.
+
+    See global.jelly for a general discussion about jelly script.
+  -->
+
+  <!--
+    Creates a text field that shows the value of the "name" property.
+    When submitted, it will be passed to the corresponding constructor parameter.
+  -->
+  <f:entry title="The name of the ImageStream to monitor" field="name">
+    <f:textbox  />
+  </f:entry>
+  <f:entry title="The specific image tag in the ImageStream to monitor" field="tag">
+    <f:textbox  />
+  </f:entry>
+  <f:entry title="URL of the OpenShift api endpoint" field="apiURL">
+    <f:textbox  />
+  </f:entry>
+  <f:entry title="The name of the project the ImageStream is stored in" field="namespace">
+    <f:textbox  />
+  </f:entry>
+  <f:entry title="The authorization token for interacting with OpenShift" field="authToken">
+    <f:textbox  />
+  </f:entry>
+  <f:entry title="Allow for verbose logging during this build step plug-in" field="verbose">
+    <f:booleanRadio default="false" />
+  </f:entry>
+</j:jelly>
+

--- a/src/main/resources/com/openshift/jenkins/plugins/pipeline/dsl/OpenShiftImageStreams/global.jelly
+++ b/src/main/resources/com/openshift/jenkins/plugins/pipeline/dsl/OpenShiftImageStreams/global.jelly
@@ -1,0 +1,1 @@
+../../OpenShiftImageStreams/global.jelly

--- a/src/main/resources/com/openshift/jenkins/plugins/pipeline/dsl/OpenShiftImageStreams/help-apiURL.html
+++ b/src/main/resources/com/openshift/jenkins/plugins/pipeline/dsl/OpenShiftImageStreams/help-apiURL.html
@@ -1,0 +1,1 @@
+../../OpenShiftImageStreams/help-apiURL.html

--- a/src/main/resources/com/openshift/jenkins/plugins/pipeline/dsl/OpenShiftImageStreams/help-authToken.html
+++ b/src/main/resources/com/openshift/jenkins/plugins/pipeline/dsl/OpenShiftImageStreams/help-authToken.html
@@ -1,0 +1,1 @@
+../../OpenShiftImageStreams/help-authToken.html

--- a/src/main/resources/com/openshift/jenkins/plugins/pipeline/dsl/OpenShiftImageStreams/help-name.html
+++ b/src/main/resources/com/openshift/jenkins/plugins/pipeline/dsl/OpenShiftImageStreams/help-name.html
@@ -1,0 +1,1 @@
+../../OpenShiftImageStreams/help-imageStreamName.html

--- a/src/main/resources/com/openshift/jenkins/plugins/pipeline/dsl/OpenShiftImageStreams/help-namespace.html
+++ b/src/main/resources/com/openshift/jenkins/plugins/pipeline/dsl/OpenShiftImageStreams/help-namespace.html
@@ -1,0 +1,1 @@
+../../OpenShiftImageStreams/help-namespace.html

--- a/src/main/resources/com/openshift/jenkins/plugins/pipeline/dsl/OpenShiftImageStreams/help-tag.html
+++ b/src/main/resources/com/openshift/jenkins/plugins/pipeline/dsl/OpenShiftImageStreams/help-tag.html
@@ -1,0 +1,1 @@
+../../OpenShiftImageStreams/help-tag.html

--- a/src/main/resources/com/openshift/jenkins/plugins/pipeline/dsl/OpenShiftImageStreams/help-verbose.html
+++ b/src/main/resources/com/openshift/jenkins/plugins/pipeline/dsl/OpenShiftImageStreams/help-verbose.html
@@ -1,0 +1,1 @@
+../../OpenShiftImageStreams/help-verbose.html


### PR DESCRIPTION
Adds an openshiftImageStream DSL step to the OpenShift pipeline plugin.

Example:

```
openshiftImageStream name: 'myimage', namespace: 'myproject', tag: 'latest', verbose: 'true'
```
