### PR TITLE
Adding exec function to Jenkins OpenShift Plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,19 @@ Optional parameters are:
 
 -  "waitTime":  Time in milliseconds to wait for deployment completion.  Default is 1 minute.
 
+#### "Run OpenShift Exec"
+
+The step name is "openshiftExec".  Mandatory parameters are:
+
+-  "pod" : The name of the pod in which to execute the command.
+-  "command" :  The name of the command to run. May be specified as `command: '/usr/bin/echo'` or in a compact form including parameters as `command: [ '/usr/bin/echo', 'hello', 'world', ... ]` 
+
+Optional parameters are:
+
+- "container" : The container name in which to run the command. If not specified, the first container in the pod will be used.
+-  "arguments" : Arguments for the command. May be specified as `arguments: [ 'arg1', 'arg2', ... ]` or `arguments: [ [ value: 'arg1' ], [ value : 'arg2' ], ... ]` 
+-  "waitTime" :  Time in milliseconds to wait for deployment completion.  Default is 1 minute.
+
 #### "Create OpenShift Resource(s)"
 
 The step name is "openshiftCreateResources".  Mandatory parameters is either:

--- a/README.md
+++ b/README.md
@@ -263,11 +263,11 @@ ImageStream.
 
 The step name is "openshiftImageStream". Mandatory parameters are:
 
-a) "name":  The name of the ImageStream to poll
+- "name":  The name of the ImageStream to poll
 
-b) "tag":  The tag to watch on the ImageStream
+- "tag":  The tag to watch on the ImageStream
 
-c) "namespace": The project for the ImageStream
+- "namespace": The project for the ImageStream
 
 
 ### Pipeline / Workflow support prior to version 1.0.14 of the OpenShift Pipeline Plugin 

--- a/pom.xml
+++ b/pom.xml
@@ -77,7 +77,7 @@
 			<groupId>org.jboss</groupId>
 			<artifactId>jboss-dmr</artifactId>
 			<version>1.3.0.Final</version>
-    </dependency>
+	</dependency>
 
 	<dependency>
 	    <groupId>com.openshift</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -77,7 +77,7 @@
 			<groupId>org.jboss</groupId>
 			<artifactId>jboss-dmr</artifactId>
 			<version>1.3.0.Final</version>
-	</dependency>
+    </dependency>
 
 	<dependency>
 	    <groupId>com.openshift</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -83,7 +83,7 @@
 	    <groupId>com.openshift</groupId>
 	    <artifactId>openshift-restclient-java</artifactId>
 	    <version>5.2.0-SNAPSHOT</version>
-	</dependency>
+	</dependency> 
     
   	<dependency>
     	<groupId>org.yaml</groupId>

--- a/src/main/java/com/openshift/jenkins/plugins/pipeline/Argument.java
+++ b/src/main/java/com/openshift/jenkins/plugins/pipeline/Argument.java
@@ -1,0 +1,38 @@
+package com.openshift.jenkins.plugins.pipeline;
+
+import hudson.Extension;
+import hudson.model.AbstractDescribableImpl;
+import hudson.model.Descriptor;
+import hudson.util.FormValidation;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.QueryParameter;
+
+public class Argument extends AbstractDescribableImpl<Argument> {
+
+    protected final String value;
+
+    @DataBoundConstructor
+    public Argument(String value) {
+        this.value = value;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+
+    @Extension
+    public static class DescriptorImpl extends Descriptor<Argument> {
+
+        @Override
+        public String getDisplayName() {
+            return "Argument";
+        }
+
+        public FormValidation doCheckValue(@QueryParameter String value) {
+            return FormValidation.validateRequired(value);
+        }
+
+    }
+
+}

--- a/src/main/java/com/openshift/jenkins/plugins/pipeline/MessageConstants.java
+++ b/src/main/java/com/openshift/jenkins/plugins/pipeline/MessageConstants.java
@@ -50,6 +50,14 @@ public static final String CANCELLED_BUILD = "  Cancelled build \"%s\".";
 public static final String EXIT_BUILD_CANCEL = "\n\nExiting \"%s\" successfully with %d builds cancelled.";
 
 /*
+ * These messages are for the OpenShift exec implementation.
+ */
+public static final String START_EXEC = "\n\nStarting \"%s\" with project \"%s\".";
+public static final String EXIT_EXEC_BAD = "\n\nExiting \"%s\" unsuccessfully: %s";
+public static final String EXIT_EXEC_GOOD = "\n\nExiting \"%s\" successfully.";
+
+
+/*
  * These messages are for the "Create OpenShift Resource(s)" jenkins build step implemented by OpenShiftCreator
  */
 public static final String START_CREATE_OBJS = "\n\nStarting \"" + OpenShiftCreator.DISPLAY_NAME + "\" with the project \"%s\".";

--- a/src/main/java/com/openshift/jenkins/plugins/pipeline/OpenShiftExec.java
+++ b/src/main/java/com/openshift/jenkins/plugins/pipeline/OpenShiftExec.java
@@ -1,0 +1,140 @@
+package com.openshift.jenkins.plugins.pipeline;
+
+import com.openshift.jenkins.plugins.pipeline.model.GlobalConfig;
+import com.openshift.jenkins.plugins.pipeline.model.IOpenShiftApiObjHandler;
+import com.openshift.jenkins.plugins.pipeline.model.IOpenShiftExec;
+import hudson.Extension;
+import hudson.model.AbstractProject;
+import hudson.tasks.BuildStepDescriptor;
+import hudson.tasks.Builder;
+import hudson.util.FormValidation;
+import net.sf.json.JSONObject;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.QueryParameter;
+import org.kohsuke.stapler.StaplerRequest;
+
+import javax.servlet.ServletException;
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+public class OpenShiftExec extends OpenShiftBaseStep implements IOpenShiftExec, IOpenShiftApiObjHandler {
+
+    protected final String pod;
+    protected final String container;
+    protected final String command;
+    protected final List<Argument> arguments;
+    protected final String waitTime;
+
+    public String getPod() {
+        return pod;
+    }
+
+    public String getContainer() {
+        return container;
+    }
+
+    public String getCommand() {
+        return command;
+    }
+
+    public List<Argument> getArguments() {
+        return arguments;
+    }
+
+    public String getWaitTime() {
+        return waitTime;
+    }
+
+    @DataBoundConstructor
+    public OpenShiftExec(String apiURL, String namespace, String authToken, String verbose, String pod, String container, String command, List<Argument>arguments, String waitTime) {
+        super( apiURL, namespace, authToken, verbose );
+        this.pod = pod.trim();
+        this.container = container.trim();
+        this.command = command;
+        this.arguments = arguments;
+        this.waitTime = waitTime.trim();
+    }
+
+    // TODO: Copied from other class boilerplate, but I don't think this works. We are passing a user specified timeout string as a map key.
+    public String getWaitTime(Map<String,String> overrides) {
+        String val = getOverride(getWaitTime(), overrides);
+        if (val.length() > 0)
+            return val;
+        return Long.toString(GlobalConfig.getBuildWait());
+    }
+
+    @Extension // This indicates to Jenkins that this is an implementation of an extension point.
+    public static final class DescriptorImpl extends BuildStepDescriptor<Builder> {
+        private long wait = GlobalConfig.BUILD_WAIT;
+
+        /**
+         * In order to load the persisted global configuration, you have to
+         * call load() in the constructor.
+         */
+        public DescriptorImpl() {
+            load();
+        }
+
+        public FormValidation doCheckApiURL(@QueryParameter String value)
+                throws IOException, ServletException {
+            return ParamVerify.doCheckApiURL(value);
+        }
+
+        public FormValidation doCheckBldCfg(@QueryParameter String value)
+                throws IOException, ServletException {
+            return ParamVerify.doCheckBldCfg(value);
+        }
+
+        public FormValidation doCheckNamespace(@QueryParameter String value)
+                throws IOException, ServletException {
+            return ParamVerify.doCheckNamespace(value);
+        }
+
+        public FormValidation doCheckWaitTime(@QueryParameter String value)
+                throws IOException, ServletException {
+            return ParamVerify.doCheckCheckForWaitTime(value);
+        }
+
+        public FormValidation doCheckAuthToken(@QueryParameter String value)
+                throws IOException, ServletException {
+            return ParamVerify.doCheckToken(value);
+        }
+
+        public FormValidation doCheckPod(@QueryParameter String value)
+                throws IOException, ServletException {
+            return FormValidation.validateRequired(value);
+        }
+
+        public FormValidation doCheckCommand(@QueryParameter String value)
+                throws IOException, ServletException {
+            return FormValidation.validateRequired(value);
+        }
+
+        public boolean isApplicable(Class<? extends AbstractProject> aClass) {
+            // Indicates that this builder can be used with all kinds of project types
+            return true;
+        }
+
+        public String getDisplayName() {
+            return DISPLAY_NAME;
+        }
+
+        public long getWait() {
+            return wait;
+        }
+
+        @Override
+        public boolean configure(StaplerRequest req, JSONObject formData) throws FormException {
+            // To persist global configuration information,
+            // pull info from formData, set appropriate instance field (which should have a getter), and call save().
+            wait = formData.getLong("wait");
+            GlobalConfig.setBuildWait(wait);
+            save();
+            return super.configure(req,formData);
+        }
+
+    }
+
+
+}

--- a/src/main/java/com/openshift/jenkins/plugins/pipeline/ParamVerify.java
+++ b/src/main/java/com/openshift/jenkins/plugins/pipeline/ParamVerify.java
@@ -1,19 +1,15 @@
 package com.openshift.jenkins.plugins.pipeline;
 
+import com.openshift.jenkins.plugins.pipeline.dsl.OpenShiftBaseStep;
 import hudson.util.FormValidation;
-
-import java.io.IOException;
-import java.util.Map;
-
-import javax.servlet.ServletException;
-
 import net.sf.json.JSONObject;
-
 import org.jboss.dmr.ModelNode;
 import org.kohsuke.stapler.QueryParameter;
 import org.yaml.snakeyaml.Yaml;
 
-import com.openshift.jenkins.plugins.pipeline.dsl.OpenShiftBaseStep;
+import javax.servlet.ServletException;
+import java.io.IOException;
+import java.util.Map;
 
 public class ParamVerify {
 	

--- a/src/main/java/com/openshift/jenkins/plugins/pipeline/dsl/OpenShiftExec.java
+++ b/src/main/java/com/openshift/jenkins/plugins/pipeline/dsl/OpenShiftExec.java
@@ -1,0 +1,196 @@
+package com.openshift.jenkins.plugins.pipeline.dsl;
+
+import com.openshift.jenkins.plugins.pipeline.Argument;
+import com.openshift.jenkins.plugins.pipeline.ParamVerify;
+import com.openshift.jenkins.plugins.pipeline.model.GlobalConfig;
+import com.openshift.jenkins.plugins.pipeline.model.IOpenShiftExec;
+import hudson.Extension;
+import hudson.model.AbstractBuild;
+import hudson.model.AbstractProject;
+import hudson.model.Action;
+import hudson.model.BuildListener;
+import hudson.tasks.BuildStepMonitor;
+import org.jenkinsci.plugins.workflow.steps.AbstractStepDescriptorImpl;
+import org.jenkinsci.plugins.workflow.steps.Step;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+public class OpenShiftExec extends OpenShiftBaseStep implements IOpenShiftExec {
+
+    protected String pod;
+    protected String container;
+    protected String command;
+    protected List<Argument> arguments = new ArrayList<>();
+    protected String waitTime;
+
+    @DataBoundConstructor
+    public OpenShiftExec( String pod ) {
+        this.pod = pod;
+    }
+
+    @DataBoundSetter
+    public void setContainer(String container) {
+        this.container = container;
+    }
+
+    @DataBoundSetter
+    public void setCommand(String command) {
+        this.command = command;
+    }
+
+    @DataBoundSetter
+    public void setArguments(List<Argument> arguments) {
+        this.arguments = arguments;
+    }
+
+    @DataBoundSetter
+    public void setWaitTime(String waitTime) {
+        this.waitTime = waitTime;
+    }
+
+    public String getPod() {
+        return pod;
+    }
+
+    public String getContainer() {
+        return container;
+    }
+
+    public String getCommand() {
+        return command;
+    }
+
+    public List<Argument> getArguments() {
+        return arguments;
+    }
+
+    public String getWaitTime() {
+        return waitTime;
+    }
+
+    public String getWaitTime(Map<String,String> overrides) {
+        String val = getOverride(getWaitTime(), overrides);
+        if (val.length() > 0)
+            return val;
+        return Long.toString(GlobalConfig.getBuildWait());
+    }
+
+	@Extension
+    public static class DescriptorImpl extends AbstractStepDescriptorImpl {
+
+        public DescriptorImpl() {
+            super(OpenShiftExecExecution.class);
+        }
+
+        @Override
+        public String getFunctionName() {
+            return "openshiftExec";
+        }
+
+        @Override
+        public String getDisplayName() {
+            return DISPLAY_NAME;
+        }
+
+        private Object requiredArgument( Map<String, Object> arguments, String arg ) {
+            Object o = arguments.get( arg );
+            if ( o == null ) {
+                throw new IllegalArgumentException( "Missing required argument: " + arg );
+            }
+            return o;
+        }
+
+        private String argumentAsString(Map<String, Object> arguments, String arg, String def ) {
+            Object o = arguments.get( arg );
+            if ( o == null ) {
+                return def;
+            }
+            return o.toString();
+        }
+
+        private String argumentAsString(Map<String, Object> arguments, String arg ) throws IllegalArgumentException {
+            return requiredArgument(arguments, arg ).toString();
+        }
+
+        @Override
+        public Step newInstance(Map<String, Object> arguments) throws Exception {
+            OpenShiftExec step = new OpenShiftExec( argumentAsString( arguments, "pod" ) );
+            step.setContainer( argumentAsString( arguments, "container", "" ) );
+
+            Object commandObject = requiredArgument( arguments, "command" );
+            if ( commandObject instanceof String ) { // command: "date"
+                step.setCommand( commandObject.toString() );
+            } else if ( commandObject instanceof List ) { // command : [ "echo", "hello", ... ]
+                List commandList = (List)commandObject;
+                Iterator i = commandList.iterator();
+                if ( ! i.hasNext() ) {
+                    throw new IllegalArgumentException( "Command list cannot be empty" );
+                }
+                step.setCommand( i.next().toString() );
+                List<Argument> commandArgs = new ArrayList<>();
+                while ( i.hasNext() ) {
+                    commandArgs.add( new Argument( i.next().toString() ) );
+                }
+                step.setArguments(commandArgs);
+            } else {
+                throw new IllegalArgumentException( "Unrecognized command syntax. It created type: " + commandObject.getClass().getName() );
+            }
+
+            Object argumentsObject = arguments.get( "arguments" );
+            if ( argumentsObject != null ) {
+                if ( argumentsObject instanceof List ) {
+                    List<Argument> commandArgs = new ArrayList<>();
+                    for ( Object o : (List)argumentsObject ) {
+                        String arg;
+                        if ( o instanceof Map ) {
+                            Object aObject = ((Map)o).get( "value" );
+                            if ( aObject == null ) {
+                                throw new IllegalArgumentException( "Expected value entry in arguments map: " + o.toString() );
+                            }
+                            arg = aObject.toString();
+                        } else {
+                            arg = o.toString();
+                        }
+                        commandArgs.add( new Argument( arg ) );
+                    }
+                    step.setArguments(commandArgs);
+                } else {
+                    throw new IllegalArgumentException( "Unrecognized arguments syntax. It created type: " + argumentsObject.getClass().getName() );
+                }
+            }
+
+            step.setWaitTime(argumentAsString( arguments, "waitTime", null));
+            ParamVerify.updateDSLBaseStep(arguments, step);
+            return step;
+        }
+
+    }
+
+    @Override
+    public boolean prebuild(AbstractBuild<?, ?> build, BuildListener listener) {
+        return true;
+    }
+
+    @Override
+    public Action getProjectAction(AbstractProject<?, ?> project) {
+        return null;
+    }
+
+    @Override
+    public Collection<? extends Action> getProjectActions(
+            AbstractProject<?, ?> project) {
+        return null;
+    }
+
+    @Override
+    public BuildStepMonitor getRequiredMonitorService() {
+        return null;
+    }
+
+}

--- a/src/main/java/com/openshift/jenkins/plugins/pipeline/dsl/OpenShiftExecExecution.java
+++ b/src/main/java/com/openshift/jenkins/plugins/pipeline/dsl/OpenShiftExecExecution.java
@@ -1,0 +1,47 @@
+package com.openshift.jenkins.plugins.pipeline.dsl;
+
+
+import hudson.AbortException;
+import hudson.EnvVars;
+import hudson.FilePath;
+import hudson.Launcher;
+import hudson.model.Computer;
+import hudson.model.Executor;
+import hudson.model.Run;
+import hudson.model.TaskListener;
+import org.jenkinsci.plugins.workflow.steps.AbstractSynchronousNonBlockingStepExecution;
+import org.jenkinsci.plugins.workflow.steps.StepContextParameter;
+
+import javax.inject.Inject;
+
+public class OpenShiftExecExecution extends AbstractSynchronousNonBlockingStepExecution<Void> {
+
+    private static final long serialVersionUID = 1L;
+
+    @StepContextParameter
+    private transient TaskListener listener;
+    @StepContextParameter
+    private transient Launcher launcher;
+    @StepContextParameter
+    private transient EnvVars envVars;
+    @StepContextParameter
+    private transient Run<?, ?> runObj;
+    @StepContextParameter
+    private transient FilePath filePath; // included as ref of what can be included for future use
+    @StepContextParameter
+    private transient Executor executor; // included as ref of what can be included for future use
+    @StepContextParameter
+    private transient Computer computer; // included as ref of what can be included for future use
+
+    @Inject
+    private transient OpenShiftExec step;
+
+    @Override
+    protected Void run() throws Exception {
+    	boolean success = step.doItCore(listener, envVars, runObj, null, launcher);
+    	if (!success) {
+    		throw new AbortException("\"" + step.getDescriptor().getDisplayName() + "\" failed");
+    	}
+    	return null;
+    }
+}

--- a/src/main/java/com/openshift/jenkins/plugins/pipeline/model/IOpenShiftExec.java
+++ b/src/main/java/com/openshift/jenkins/plugins/pipeline/model/IOpenShiftExec.java
@@ -1,0 +1,126 @@
+package com.openshift.jenkins.plugins.pipeline.model;
+
+import com.openshift.jenkins.plugins.pipeline.Argument;
+import com.openshift.jenkins.plugins.pipeline.MessageConstants;
+import com.openshift.restclient.IClient;
+import com.openshift.restclient.ResourceKind;
+import com.openshift.restclient.api.capabilities.IPodExec;
+import com.openshift.restclient.capability.CapabilityVisitor;
+import com.openshift.restclient.capability.IStoppable;
+import com.openshift.restclient.model.IPod;
+import hudson.Launcher;
+import hudson.model.TaskListener;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+public interface IOpenShiftExec extends IOpenShiftPlugin {
+
+	String DISPLAY_NAME = "OpenShift Exec";
+
+	String getPod();
+
+	String getContainer();
+
+	String getCommand();
+
+	List<Argument> getArguments();
+
+	String getWaitTime();
+
+	default String getDisplayName() {
+		return DISPLAY_NAME;
+	}
+
+	String getWaitTime(Map<String, String> overrides);
+
+	default boolean coreLogic(Launcher launcher, TaskListener listener, Map<String, String> overrides) {
+		listener.getLogger().println(String.format(MessageConstants.START_EXEC, DISPLAY_NAME, getNamespace(overrides)));
+		List<String> fullCommand = new ArrayList<>();
+		fullCommand.add(getCommand());
+		getArguments().forEach( a -> fullCommand.add( a.getValue() ) );
+
+		IPodExec.Options options = new IPodExec.Options();
+		if ( !getContainer().isEmpty() ) {
+			options.container( getContainer() );
+		}
+
+		// get oc client
+		IClient client = this.getClient(listener, DISPLAY_NAME, overrides);
+		if ( client == null ) {
+			listener.getLogger().println(String.format(MessageConstants.EXIT_EXEC_BAD, DISPLAY_NAME, "Unable to obtain rest client"));
+			return false;
+		}
+
+		IPod p = null;
+		for ( int retries = 10; p == null; retries-- ) {
+			try {
+				p = client.get( ResourceKind.POD, getPod(), getNamespace());
+			} catch ( Exception e ) {
+				if ( retries == 1 ) {
+					listener.getLogger().println(String.format(MessageConstants.EXIT_EXEC_BAD, DISPLAY_NAME, "Unable to find pod: " + getPod()));
+					e.printStackTrace( listener.getLogger() );
+					return false;
+				}
+				try { Thread.sleep( 6000 ); } catch ( InterruptedException ie ) {}
+			}
+		}
+
+		final CountDownLatch latch = new CountDownLatch(1);
+
+		IStoppable exec = p.accept(new CapabilityVisitor<IPodExec, IStoppable>() {
+			@Override
+			public IStoppable visit(IPodExec capability) {
+				return capability.start( new IPodExec.IPodExecOutputListener() {
+
+					@Override
+					public void onOpen() {
+						listener.getLogger().println( "Connection opened for exec operation" );
+					}
+
+					@Override
+					public void onStdOut(String message) {
+						listener.getLogger().println( "stdout> " + message );
+					}
+
+					@Override
+					public void onStdErr(String message) {
+						listener.getLogger().println( "stderr> " + message );
+					}
+
+					@Override
+					public void onExecErr(String message) {
+						listener.error( "Error during exec: " + message );
+					}
+
+					@Override
+					public void onClose(int code, String reason) {
+						listener.getLogger().printf( "Connection closed for exec operation [%d]: %s\n", code, reason  );
+						latch.countDown();
+					}
+
+					@Override
+					public void onFailure(IOException e) {
+						listener.error( "Failure during exec: " + e.getMessage() );
+						e.printStackTrace();
+						latch.countDown();
+					}
+
+				}, options, fullCommand.toArray(new String[]{}) );
+			}
+		}, null);
+
+		try {
+			latch.await( Integer.parseInt( getWaitTime( overrides ) ), TimeUnit.SECONDS );
+		} catch ( InterruptedException ie ) {}
+
+		listener.getLogger().println(String.format(MessageConstants.EXIT_EXEC_GOOD, DISPLAY_NAME));
+		return true;
+	}
+
+
+}

--- a/src/main/resources/com/openshift/jenkins/plugins/pipeline/Argument/config.jelly
+++ b/src/main/resources/com/openshift/jenkins/plugins/pipeline/Argument/config.jelly
@@ -1,0 +1,11 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+  <f:entry title="Value" field="value">
+    <f:textbox  />
+  </f:entry>
+  <f:entry>
+    <div align="right">
+        <f:repeatableDeleteButton/>
+    </div>
+  </f:entry>
+</j:jelly>

--- a/src/main/resources/com/openshift/jenkins/plugins/pipeline/Argument/global.jelly
+++ b/src/main/resources/com/openshift/jenkins/plugins/pipeline/Argument/global.jelly
@@ -1,0 +1,15 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+  <!--
+    This Jelly script is used to produce the global configuration option.
+
+    Jenkins uses a set of tag libraries to provide uniformity in forms.
+    To determine where this tag is defined, first check the namespace URI,
+    and then look under $JENKINS/views/. For example, <f:section> is defined
+    in $JENKINS/views/lib/form/section.jelly.
+
+    It's also often useful to just check other similar scripts to see what
+    tags they use. Views are always organized according to its owner class,
+    so it should be straightforward to find them.
+  -->
+</j:jelly>

--- a/src/main/resources/com/openshift/jenkins/plugins/pipeline/Argument/help-value.html
+++ b/src/main/resources/com/openshift/jenkins/plugins/pipeline/Argument/help-value.html
@@ -1,0 +1,3 @@
+<div>
+  The value for the environment variable.
+</div>

--- a/src/main/resources/com/openshift/jenkins/plugins/pipeline/OpenShiftExec/config.jelly
+++ b/src/main/resources/com/openshift/jenkins/plugins/pipeline/OpenShiftExec/config.jelly
@@ -1,0 +1,40 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+
+  <f:entry title="URL of the OpenShift api endpoint" field="apiURL">
+    <f:textbox  />
+  </f:entry>
+
+  <f:entry title="The authorization token for interacting with OpenShift" field="authToken">
+    <f:textbox  />
+  </f:entry>
+
+  <f:entry title="The pod in which to execute the command" field="pod">
+    <f:textbox  />
+  </f:entry>
+
+  <f:entry title="The name of the project in which the pod resides" field="namespace">
+    <f:textbox  />
+  </f:entry>
+
+  <f:entry title="The container in which to execute the command" field="container">
+    <f:textbox  />
+  </f:entry>
+
+  <f:entry title="The command to execute" field="command">
+    <f:textbox  />
+  </f:entry>
+
+  <f:entry title="Arguments for the specified command" field="arguments">
+    <f:repeatableProperty field="arguments"  minimum="0" />
+  </f:entry>
+
+  <f:entry title="Allow for verbose logging during this build step plug-in" field="verbose">
+    <f:booleanRadio default="false" />
+  </f:entry>
+
+  <f:entry title="Maximum wait time" field="waitTime">
+    <f:textbox />
+  </f:entry>
+
+</j:jelly>

--- a/src/main/resources/com/openshift/jenkins/plugins/pipeline/OpenShiftExec/global.jelly
+++ b/src/main/resources/com/openshift/jenkins/plugins/pipeline/OpenShiftExec/global.jelly
@@ -1,0 +1,3 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+</j:jelly>

--- a/src/main/resources/com/openshift/jenkins/plugins/pipeline/OpenShiftExec/help-apiURL.html
+++ b/src/main/resources/com/openshift/jenkins/plugins/pipeline/OpenShiftExec/help-apiURL.html
@@ -1,0 +1,7 @@
+<div>
+  This would be the value you specify if you leverage the 
+  --server option on the OpenShift `oc` command.  If nothing
+  is specified, the plugin will inspect the KUBERNETES_SERVICE_HOST
+  environment variable.  If that variable is not set, the plugin
+  will attempt to connect to "https://openshift.default.svc.cluster.local".
+</div>

--- a/src/main/resources/com/openshift/jenkins/plugins/pipeline/OpenShiftExec/help-arguments.html
+++ b/src/main/resources/com/openshift/jenkins/plugins/pipeline/OpenShiftExec/help-arguments.html
@@ -1,0 +1,3 @@
+<div>
+  Specify a list of arguments to pass to the command.
+</div>

--- a/src/main/resources/com/openshift/jenkins/plugins/pipeline/OpenShiftExec/help-authToken.html
+++ b/src/main/resources/com/openshift/jenkins/plugins/pipeline/OpenShiftExec/help-authToken.html
@@ -1,0 +1,6 @@
+<div>
+  The value here is what 
+  you supply with the --token option when invoking the OpenShift `oc` command.  If you do 
+  not supply a value, the plugin will assume it is running in the OpenShift Jenkins 
+  image and attempt to load the kubernetes service account token stored in that image.
+</div>

--- a/src/main/resources/com/openshift/jenkins/plugins/pipeline/OpenShiftExec/help-command.html
+++ b/src/main/resources/com/openshift/jenkins/plugins/pipeline/OpenShiftExec/help-command.html
@@ -1,0 +1,3 @@
+<div>
+  The name of the command to execute.
+</div>

--- a/src/main/resources/com/openshift/jenkins/plugins/pipeline/OpenShiftExec/help-container.html
+++ b/src/main/resources/com/openshift/jenkins/plugins/pipeline/OpenShiftExec/help-container.html
@@ -1,0 +1,3 @@
+<div>
+  The container in which to execute a command. If not specified, the first container in the pod will be used.
+</div>

--- a/src/main/resources/com/openshift/jenkins/plugins/pipeline/OpenShiftExec/help-namespace.html
+++ b/src/main/resources/com/openshift/jenkins/plugins/pipeline/OpenShiftExec/help-namespace.html
@@ -1,0 +1,4 @@
+<div>
+  The value here should match the value from the output from `oc project` if you created the resources related to this task from the command line.
+  If nothing is specified, the plugin will inspect the PROJECT_NAME environment variable.
+</div>

--- a/src/main/resources/com/openshift/jenkins/plugins/pipeline/OpenShiftExec/help-pod.html
+++ b/src/main/resources/com/openshift/jenkins/plugins/pipeline/OpenShiftExec/help-pod.html
@@ -1,0 +1,3 @@
+<div>
+  The pod in which to execute a command.
+</div>

--- a/src/main/resources/com/openshift/jenkins/plugins/pipeline/OpenShiftExec/help-verbose.html
+++ b/src/main/resources/com/openshift/jenkins/plugins/pipeline/OpenShiftExec/help-verbose.html
@@ -1,0 +1,3 @@
+<div>
+  This flag is the toggle for turning on or off detailed logging in this plug-in.
+</div>

--- a/src/main/resources/com/openshift/jenkins/plugins/pipeline/OpenShiftExec/help-waitTime.html
+++ b/src/main/resources/com/openshift/jenkins/plugins/pipeline/OpenShiftExec/help-waitTime.html
@@ -1,0 +1,4 @@
+<div>
+  Specify in milliseconds the amount of time to wait for build completion.  If nothing is specified, the amount specified 
+  at the global `OpenShift Builder` wait interval will be used.
+</div>

--- a/src/main/resources/com/openshift/jenkins/plugins/pipeline/dsl/OpenShiftExec/config.jelly
+++ b/src/main/resources/com/openshift/jenkins/plugins/pipeline/dsl/OpenShiftExec/config.jelly
@@ -1,0 +1,1 @@
+../../OpenShiftExec/config.jelly

--- a/src/main/resources/com/openshift/jenkins/plugins/pipeline/dsl/OpenShiftExec/global.jelly
+++ b/src/main/resources/com/openshift/jenkins/plugins/pipeline/dsl/OpenShiftExec/global.jelly
@@ -1,0 +1,1 @@
+../../OpenShiftExec/global.jelly

--- a/src/main/resources/com/openshift/jenkins/plugins/pipeline/dsl/OpenShiftExec/help-apiURL.html
+++ b/src/main/resources/com/openshift/jenkins/plugins/pipeline/dsl/OpenShiftExec/help-apiURL.html
@@ -1,0 +1,1 @@
+../../OpenShiftExec/help-apiURL.html

--- a/src/main/resources/com/openshift/jenkins/plugins/pipeline/dsl/OpenShiftExec/help-arguments.html
+++ b/src/main/resources/com/openshift/jenkins/plugins/pipeline/dsl/OpenShiftExec/help-arguments.html
@@ -1,0 +1,1 @@
+../../OpenShiftExec/help-arguments.html

--- a/src/main/resources/com/openshift/jenkins/plugins/pipeline/dsl/OpenShiftExec/help-authToken.html
+++ b/src/main/resources/com/openshift/jenkins/plugins/pipeline/dsl/OpenShiftExec/help-authToken.html
@@ -1,0 +1,1 @@
+../../OpenShiftExec/help-authToken.html

--- a/src/main/resources/com/openshift/jenkins/plugins/pipeline/dsl/OpenShiftExec/help-command.html
+++ b/src/main/resources/com/openshift/jenkins/plugins/pipeline/dsl/OpenShiftExec/help-command.html
@@ -1,0 +1,1 @@
+../../OpenShiftExec/help-command.html

--- a/src/main/resources/com/openshift/jenkins/plugins/pipeline/dsl/OpenShiftExec/help-container.html
+++ b/src/main/resources/com/openshift/jenkins/plugins/pipeline/dsl/OpenShiftExec/help-container.html
@@ -1,0 +1,1 @@
+../../OpenShiftExec/help-container.html

--- a/src/main/resources/com/openshift/jenkins/plugins/pipeline/dsl/OpenShiftExec/help-namespace.html
+++ b/src/main/resources/com/openshift/jenkins/plugins/pipeline/dsl/OpenShiftExec/help-namespace.html
@@ -1,0 +1,1 @@
+../../OpenShiftExec/help-namespace.html

--- a/src/main/resources/com/openshift/jenkins/plugins/pipeline/dsl/OpenShiftExec/help-pod.html
+++ b/src/main/resources/com/openshift/jenkins/plugins/pipeline/dsl/OpenShiftExec/help-pod.html
@@ -1,0 +1,1 @@
+../../OpenShiftExec/help-pod.html

--- a/src/main/resources/com/openshift/jenkins/plugins/pipeline/dsl/OpenShiftExec/help-verbose.html
+++ b/src/main/resources/com/openshift/jenkins/plugins/pipeline/dsl/OpenShiftExec/help-verbose.html
@@ -1,0 +1,1 @@
+../../OpenShiftExec/help-verbose.html

--- a/src/main/resources/com/openshift/jenkins/plugins/pipeline/dsl/OpenShiftExec/help-waitTime.html
+++ b/src/main/resources/com/openshift/jenkins/plugins/pipeline/dsl/OpenShiftExec/help-waitTime.html
@@ -1,0 +1,1 @@
+../../OpenShiftExec/help-waitTime.html


### PR DESCRIPTION
Adding exec function for card:
https://trello.com/c/Yl4qomsw/878-5-additional-jenkins-plugin-enhancement-requests-from-github

Depends on openshift/openshift-restclient-java#220

ptal @gabemontero , @bparees 

Example verbose DSL:

```
       openshiftExec( apiURL: 'https://10.13.137.145:8443', 
        authToken: 'LsGHr_1XPhCkBVc7p6TivqVpvtDs0BDm9dIL8RdK0vU', 
        command: 'echo',
        arguments: [ [ value: 'hello'], [value: 'world'] ],
        namespace: 'myproject', 
        pod: 'ruby-hello-world-1-6939a', 
        verbose: 'true', 
        waitTime: '120000' 
       )
```

Example compact DSL (command and arguments in one groovy list):

```
       openshiftExec( apiURL: 'https://10.13.137.145:8443', 
         ...
        command: [ 'echo', 'hello', 'world' ],
       )
```

![screenshot from 2016-10-04 11-43-07](https://cloud.githubusercontent.com/assets/19783215/19081321/df53129e-8a27-11e6-8dcb-08d70435799d.png)
