### PR TITLE
Adding support for multitag

### DIFF
--- a/PR-Testing/README
+++ b/PR-Testing/README
@@ -5,10 +5,13 @@ the test-openshift-pipeline-plugin job, it will be the hpi file from your PR.  B
 you have to the plugin in the same way.
 
 The `docker build` command used, if run from the same directory as this README, and if an "openshift-pipeline.jpi" file
-exists in the "jpi" subdirectory, is:  docker build -f ./Dockerfile-jenkins-test-new-plugin -t openshift/jenkins-plugin-snapshot-test:latest .
+exists in the "jpi" subdirectory, is:
+    docker build -f ./Dockerfile-jenkins-test-new-plugin -t openshift/jenkins-plugin-snapshot-test:latest .
 
 The next step is to  then run the extended tests for the plugin located at https://github.com/openshift/origin.
-From the top level directory of a clone of that repository, this command is run:  test/extended/core.sh --ginkgo.focus='openshift pipeline plugin' -ginkgo.v"
+From the top level directory of a clone of that repository, this command is run:
+    test/extended/core.sh --ginkgo.focus='openshift pipeline plugin' -ginkgo.v
 
-That extended test typically verifies the functionality of the openshift-pipeline plugin installed into OpenShift's official jenkins image (see https://github.com/openshift/jenkins),
-but it will look for the local existence of the openshift/jenkins-plugin-snapshot-test:latest image, and if present, deploy and test against that image instead.
+That extended test typically verifies the functionality of the openshift-pipeline plugin installed into OpenShift's
+official jenkins image (see https://github.com/openshift/jenkins), but it will look for the local existence of
+the openshift/jenkins-plugin-snapshot-test:latest image, and if present, deploy and test against that image instead.

--- a/PR-Testing/jpi/README
+++ b/PR-Testing/jpi/README
@@ -1,2 +1,3 @@
-Any openshift-pipelin.hpi to be tested is copied here as `openshift-pipeline.jpi` and then incorporated into a jenkins image built via a `docker build` using the Dockerfile in the parent directory to this directory.
+Any openshift-pipeline.hpi to be tested is copied here as `openshift-pipeline.jpi` and then incorporated
+into a jenkins image built via a `docker build` using the Dockerfile in the parent directory to this directory.
 The resulting image can then be used for testing.

--- a/README.md
+++ b/README.md
@@ -181,21 +181,31 @@ Optional parameters are:
 
 The step name is "openshiftTag".  Mandatory parameters are:
 
-- "sourceStream" or "srcStream":  The ImageStream of the existing image.
+-  "sourceStream" or "srcStream":  The ImageStream of the existing image.
 
-- "sourceTag" or "srcTag":  The tag (ImageStreamTag type) or ID (ImageStreamImage type) of the existing image.
+-  "sourceTag" or "srcTag":  The tag (ImageStreamTag type) or ID (ImageStreamImage type) of the existing image. 
 
-- "destinationStream" or "destStream":  The ImageStream for the new tag.
+-  "destinationStream" or "destStream":  The ImageStream for the new tag. A comma delimited list can be specified.
 
-- "destinationTag" or "destTag":  The name of the new tag.
+-  "destinationTag" or "destTag":  The name of the new tag. A comma delimited list can be specified.
+
+    The following combinations are supported:
+    1. 1 destination stream and 1 destination tag   (i.e. single tag applies to single stream)
+        - `destinationStream: 'stream1', destinationTag: 'tag1'`
+    1. 1 destination stream and N destination tags   (i.e. all tags apply to the same stream)
+        - `destinationStream: 'stream1', destinationTag: 'tag1, tag2'`
+    1. 1 destination tag and N destination streams	(i.e. all streams will get the same tag)
+        - `destinationStream: 'stream1, stream2', destinationTag: 'tag1'`
+    1. N destination streams and N destination tags	(i.e. each index will be combined to form a unique stream:tag combination)
+        - `destinationStream: 'stream1, stream2', destinationTag: 'tag1, tag2'`
 
 Optional parameters are:
 
-- "alias":  Whether to update destination tag whenever the source tag changes.  Equivalent of the `--alias` option for the `oc tag` command. When false, the destination tag type is "ImageStreamImage", and when true, the destination tag type is "ImageStreamTag".
+-  "alias":  Whether to update destination tag whenever the source tag changes.  Equivalent of the `--alias` option for the `oc tag` command. When false, the destination tag type is "ImageStreamImage", and when true, the destination tag type is "ImageStreamTag".
 
-- "destinationNamespace":  The name of the project to host the destinationStream:destinationTag.  If nothing is specified, the plugin will inspect the PROJECT_NAME environment variable.
+-  "destinationNamespace":  The name of the project to host the destinationStream:destinationTag.  If nothing is specified, the plugin will use the source namespace.
 
-- "destinationAuthToken":  The authorization token for interacting with the destinationNamespace.  If you do not supply a value, the plugin will assume it is running in the OpenShift Jenkins image and attempt to load the kubernetes service account token stored in that image.
+-  "destinationAuthToken":  The authorization token for interacting with the destinationNamespace.  If you do not supply a value, the plugin will assume it is running in the OpenShift Jenkins image and attempt to load the kubernetes service account token stored in that image.
 
 ####  "Verify OpenShift Build"
 

--- a/src/main/java/com/openshift/jenkins/plugins/pipeline/MessageConstants.java
+++ b/src/main/java/com/openshift/jenkins/plugins/pipeline/MessageConstants.java
@@ -133,7 +133,7 @@ public static final String SCM_NO_CHANGE = "\n\n No revision change found this p
 /*
  * These messages are for the "Tag OpenShift Image" jenkins build step implemented by OpenShiftImageTagger
  */
-public static final String START_TAG = "\n\nStarting \"" + OpenShiftImageTagger.DISPLAY_NAME + "\" with the source [image stream:tag] \"%s:%s\" from the project \"%s\" and destination [image stream:tag] \"%s:%s\" from the project \"%s\".";
+public static final String START_TAG = "\n\nStarting \"" + OpenShiftImageTagger.DISPLAY_NAME + "\" with the source [image stream:tag] \"%s:%s\" from the project \"%s\" and destination stream(s) \"%s\" with tag(s) \"%s\" from the project \"%s\".";
 public static final String EXIT_TAG_CANNOT_CREATE_DEST_IS = "\n\nExiting \"" + OpenShiftImageTagger.DISPLAY_NAME + "\" unsuccessfully; could not create the image stream \"%s\" in the project \"%s\".";
 public static final String EXIT_TAG_CANNOT_GET_IS = "\n\nExiting \"" + OpenShiftImageTagger.DISPLAY_NAME + "\" unsuccessfully; could not retrieve the image stream \"%s\" from the project \"%s\".";
 public static final String EXIT_TAG_NOT_FOUND = "\n\nExisting \"" + OpenShiftImageTagger.DISPLAY_NAME + "\" unsuccessfully; could not fine either an image tag or ID \"%s\" associated with the image stream \"%s\".";

--- a/src/main/java/com/openshift/jenkins/plugins/pipeline/OpenShiftImageTagger.java
+++ b/src/main/java/com/openshift/jenkins/plugins/pipeline/OpenShiftImageTagger.java
@@ -1,23 +1,18 @@
 package com.openshift.jenkins.plugins.pipeline;
-import hudson.Extension;
-import hudson.util.FormValidation;
-import hudson.model.AbstractProject;
-import hudson.tasks.Builder;
-import hudson.tasks.BuildStepDescriptor;
-import net.sf.json.JSONObject;
-
-import org.kohsuke.stapler.DataBoundConstructor;
-import org.kohsuke.stapler.StaplerRequest;
-import org.kohsuke.stapler.QueryParameter;
 
 import com.openshift.jenkins.plugins.pipeline.model.IOpenShiftImageTagger;
-//import com.openshift.restclient.authorization.TokenAuthorizationStrategy;
-
+import hudson.Extension;
+import hudson.model.AbstractProject;
+import hudson.tasks.BuildStepDescriptor;
+import hudson.tasks.Builder;
+import hudson.util.FormValidation;
+import net.sf.json.JSONObject;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.QueryParameter;
+import org.kohsuke.stapler.StaplerRequest;
 
 import javax.servlet.ServletException;
-
 import java.io.IOException;
-//import java.util.Map;
 
 public class OpenShiftImageTagger extends OpenShiftBaseStep implements IOpenShiftImageTagger {
 
@@ -29,9 +24,7 @@ public class OpenShiftImageTagger extends OpenShiftBaseStep implements IOpenShif
     protected final String destinationNamespace;
     protected final String destinationAuthToken;
     protected final String alias;
-    // marked transient so don't serialize these next 2 in the workflow plugin flow; constructed on per request basis
-//    protected transient TokenAuthorizationStrategy destinationBearerToken;
-    
+
     // Fields in config.jelly must match the parameter names in the "DataBoundConstructor"
     @DataBoundConstructor
     public OpenShiftImageTagger(String apiURL, String testTag, String prodTag, String namespace, String authToken, String verbose, String testStream, String prodStream, String destinationNamespace, String destinationAuthToken, String alias) {
@@ -54,19 +47,39 @@ public class OpenShiftImageTagger extends OpenShiftBaseStep implements IOpenShif
 		return alias;
 	}
 
-	public String getTestTag() {
+    @Deprecated
+    public String getTestTag() {
+        return testTag;
+    }
+
+	public String getSrcTag() {
 		return testTag;
 	}
 
-	public String getProdTag() {
-		return prodTag;
+    @Deprecated
+    public String getProdTag() {
+        return prodTag;
+    }
+
+    public String getDestTag() {
+        return prodTag;
 	}
-	
-	public String getTestStream() {
+
+    @Deprecated
+    public String getTestStream() {
+        return testStream;
+    }
+
+    public String getSrcStream() {
 		return testStream;
 	}
 
-	public String getProdStream() {
+    @Deprecated
+    public String getProdStream() {
+        return prodStream;
+    }
+
+    public String getDestStream() {
 		return prodStream;
 	}
 
@@ -77,15 +90,6 @@ public class OpenShiftImageTagger extends OpenShiftBaseStep implements IOpenShif
 	public String getDestinationAuthToken() {
 		return this.destinationAuthToken;
 	}
-	
-/*	public TokenAuthorizationStrategy getDestinationToken() {
-		return destinationBearerToken;
-	}
-	
-	public void setDestinationToken(TokenAuthorizationStrategy token) {
-		destinationBearerToken = token;
-	}
-*/	
 	
     // Overridden for better type safety.
     // If your plugin doesn't really define any property on Descriptor,

--- a/src/main/java/com/openshift/jenkins/plugins/pipeline/dsl/OpenShiftImageTagger.java
+++ b/src/main/java/com/openshift/jenkins/plugins/pipeline/dsl/OpenShiftImageTagger.java
@@ -1,24 +1,19 @@
 package com.openshift.jenkins.plugins.pipeline.dsl;
+import com.openshift.jenkins.plugins.pipeline.ParamVerify;
+import com.openshift.jenkins.plugins.pipeline.model.IOpenShiftImageTagger;
 import hudson.Extension;
-import hudson.model.Action;
-import hudson.model.BuildListener;
 import hudson.model.AbstractBuild;
 import hudson.model.AbstractProject;
+import hudson.model.Action;
+import hudson.model.BuildListener;
 import hudson.tasks.BuildStepMonitor;
-
 import org.jenkinsci.plugins.workflow.steps.AbstractStepDescriptorImpl;
 import org.jenkinsci.plugins.workflow.steps.Step;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 
-import com.openshift.jenkins.plugins.pipeline.ParamVerify;
-import com.openshift.jenkins.plugins.pipeline.model.IOpenShiftImageTagger;
-//import com.openshift.restclient.authorization.TokenAuthorizationStrategy;
-
 import java.util.Collection;
 import java.util.Map;
-import java.util.logging.Logger;
-
 
 public class OpenShiftImageTagger extends OpenShiftBaseStep implements IOpenShiftImageTagger {
 	
@@ -30,9 +25,7 @@ public class OpenShiftImageTagger extends OpenShiftBaseStep implements IOpenShif
     protected String destinationNamespace;
     protected String destinationAuthToken;
     protected String alias;
-    // marked transient so don't serialize these next 2 in the workflow plugin flow; constructed on per request basis
-    //protected transient TokenAuthorizationStrategy destinationBearerToken;
-    
+
     // Fields in config.jelly must match the parameter names in the "DataBoundConstructor"
     @DataBoundConstructor
     public OpenShiftImageTagger(String srcStream, String srcTag, String destStream, String destTag) {
@@ -107,19 +100,6 @@ public class OpenShiftImageTagger extends OpenShiftBaseStep implements IOpenShif
 		this.destinationAuthToken = destinationAuthToken;
 	}
 	
-/*	public TokenAuthorizationStrategy getDestinationToken() {
-		return destinationBearerToken;
-	}
-	
-	public void setDestinationToken(TokenAuthorizationStrategy token) {
-		destinationBearerToken = token;
-	}
-*/	
-	
-	
-    private static final Logger LOGGER = Logger.getLogger(OpenShiftImageTagger.class.getName());
-
-
 	@Extension
     public static class DescriptorImpl extends AbstractStepDescriptorImpl {
 

--- a/src/main/java/com/openshift/jenkins/plugins/pipeline/model/IOpenShiftImageTagger.java
+++ b/src/main/java/com/openshift/jenkins/plugins/pipeline/model/IOpenShiftImageTagger.java
@@ -1,25 +1,19 @@
 package com.openshift.jenkins.plugins.pipeline.model;
 
-import hudson.Launcher;
-import hudson.model.TaskListener;
-
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-
-import org.jboss.dmr.ModelNode;
-import org.jboss.dmr.ModelType;
-
 import com.openshift.internal.restclient.model.ImageStream;
 import com.openshift.jenkins.plugins.pipeline.Auth;
 import com.openshift.jenkins.plugins.pipeline.MessageConstants;
 import com.openshift.jenkins.plugins.pipeline.OpenShiftCreator;
 import com.openshift.restclient.IClient;
+import com.openshift.restclient.OpenShiftException;
 import com.openshift.restclient.ResourceKind;
-//import com.openshift.restclient.authorization.TokenAuthorizationStrategy;
 import com.openshift.restclient.model.IImageStream;
+import hudson.Launcher;
+import hudson.model.TaskListener;
+import org.jboss.dmr.ModelNode;
+import org.jboss.dmr.ModelType;
+
+import java.util.*;
 
 public interface IOpenShiftImageTagger extends IOpenShiftPlugin {
 
@@ -29,42 +23,38 @@ public interface IOpenShiftImageTagger extends IOpenShiftPlugin {
 		return DISPLAY_NAME;
 	}
 	
-	public String getAlias();
+	String getAlias();
 	
-	public String getTestTag();
+	String getSrcTag();
 	
-	public String getProdTag();
+	String getDestTag();
 		
-	public String getTestStream();
+	String getSrcStream();
 	
-	public String getProdStream();
+	String getDestStream();
 	
-	public String getDestinationNamespace();
+	String getDestinationNamespace();
 		
-	public String getDestinationAuthToken();
+	String getDestinationAuthToken();
 		
-/*	public TokenAuthorizationStrategy getDestinationToken();
-	
-	public void setDestinationToken(TokenAuthorizationStrategy token);
-*/	
 	default String getAlias(Map<String,String> overrides) {
 		return getOverride(getAlias(), overrides);
 	}
 	
-	default String getTestTag(Map<String,String> overrides) {
-		return getOverride(getTestTag(), overrides);
+	default String getSrcTag(Map<String,String> overrides) {
+		return getOverride(getSrcTag(), overrides);
 	}
 	
-	default String getProdTag(Map<String,String> overrides) {
-		return getOverride(getProdTag(), overrides);
+	default String getDestTag(Map<String,String> overrides) {
+		return getOverride(getDestTag(), overrides);
 	}
 	
-	default String getTestStream(Map<String,String> overrides) {
-		return getOverride(getTestStream(), overrides);
+	default String getSrcStream(Map<String,String> overrides) {
+		return getOverride(getSrcStream(), overrides);
 	}
 	
-	default String getProdStream(Map<String,String> overrides) {
-		return getOverride(getProdStream(), overrides);
+	default String getDestStream(Map<String,String> overrides) {
+		return getOverride(getDestStream(), overrides);
 	}
 	
 	default String getDestinationNamespace(Map<String,String> overrides) {
@@ -79,10 +69,10 @@ public interface IOpenShiftImageTagger extends IOpenShiftPlugin {
 		return getOverride(getDestinationAuthToken(), overrides);
 	}
 	
-	default String deriveImageID(String testTag, IImageStream srcIS) {
-    	String srcImageID = srcIS.getImageId(testTag);
+	default String deriveImageID(String srcTag, IImageStream srcIS) {
+    	String srcImageID = srcIS.getImageId(srcTag);
     	if (srcImageID != null && srcImageID.length() > 0) {
-    		// testTag an valid ImageStreamTag, so translating to an ImageStreamImage
+    		// srcTag an valid ImageStreamTag, so translating to an ImageStreamImage
         	srcImageID = srcIS.getName() + "@" + (srcImageID.startsWith("sha256:") ? srcImageID.substring(7) : srcImageID);
         	return srcImageID;
     	} else {
@@ -99,9 +89,9 @@ public interface IOpenShiftImageTagger extends IOpenShiftPlugin {
     			ModelNode items = tagWrapper.get("items");
     			for (ModelNode itemWrapper : items.asList()) {
     				ModelNode image = itemWrapper.get("image");
-    				if (image != null && (image.asString().equals(testTag) ||
-    									  image.asString().substring(7).equals(testTag))) {
-    					return srcIS.getName() + "@" + (testTag.startsWith("sha256:") ? testTag.substring(7) : testTag);
+    				if (image != null && (image.asString().equals(srcTag) ||
+    									  image.asString().substring(7).equals(srcTag))) {
+    					return srcIS.getName() + "@" + (srcTag.startsWith("sha256:") ? srcTag.substring(7) : srcTag);
     				}
     			}
     		}
@@ -132,113 +122,161 @@ public interface IOpenShiftImageTagger extends IOpenShiftPlugin {
 	}
 
 	default boolean coreLogic(Launcher launcher, TaskListener listener, Map<String,String> overrides) {
-    	listener.getLogger().println(String.format(MessageConstants.START_TAG, getTestStream(overrides), getTestTag(overrides), getNamespace(overrides), getProdStream(overrides), getProdTag(overrides), getDestinationNamespace(overrides)));
+		final String srcStream = getSrcStream(overrides);
+		final String srcTag = getSrcTag(overrides);
+		final String srcNS = getNamespace(overrides);
+
+		final String destStreams = getDestStream(overrides);
+		final String destTags = getDestTag(overrides);
+		final String destNS = getDestinationNamespace(overrides).isEmpty()?srcNS:getDestinationNamespace(overrides);
+
+
+    	listener.getLogger().println(String.format(MessageConstants.START_TAG, srcStream, srcTag, srcNS, destStreams, destTags, destNS ) );
     	boolean chatty = Boolean.parseBoolean(getVerbose(overrides));
     	boolean useTag = Boolean.parseBoolean(getAlias(overrides));
     	
-    	// get oc clients 
-    	IClient client = this.getClient(listener, DISPLAY_NAME, overrides);
-   		//setDestinationToken(new TokenAuthorizationStrategy(Auth.deriveBearerToken(null, getDestinationAuthToken(overrides), listener, chatty)));
-    	
-    	if (client != null) {
+    	IClient srcClient = this.getClient(listener, DISPLAY_NAME, overrides);
+
+    	if (srcClient != null) {
     		// get src id
-    		IImageStream srcIS = client.get(ResourceKind.IMAGE_STREAM, getTestStream(overrides), getNamespace(overrides));
+    		IImageStream srcIS = srcClient.get(ResourceKind.IMAGE_STREAM, srcStream, srcNS);
     		if (srcIS == null) {
-    			listener.getLogger().println(String.format(MessageConstants.EXIT_TAG_CANNOT_GET_IS, getTestStream(overrides), getNamespace(overrides)));
+    			listener.getLogger().println(String.format(MessageConstants.EXIT_TAG_CANNOT_GET_IS, srcStream, srcNS ));
     			return false;
     		}
     		
-        	if (chatty)
-        		listener.getLogger().println("\n tag before verification: " + getTestTag(overrides) + " and alias " + useTag);
+        	if (chatty) {
+				listener.getLogger().println("\n tag before verification: " + srcTag + " and alias " + useTag);
+			}
         	
         	String srcImageID = null;
         	String tagType = "ImageStreamTag";
         	if (!useTag) {
         		tagType = "ImageStreamImage";
-        		srcImageID = deriveImageID(getTestTag(overrides), srcIS);
+        		srcImageID = deriveImageID(srcTag, srcIS);
         	} else {
         		Collection<String> tags = srcIS.getTagNames();
         		Iterator<String> iter = tags.iterator();
         		while (iter.hasNext()) {
         			String tag = iter.next();
-        			if (getTestTag(overrides).equals(tag)) {
-        				srcImageID = getTestStream(overrides) + ":" + tag;
+        			if (srcTag.equals(tag)) {
+        				srcImageID = srcStream + ":" + tag;
         				break;
         			}
         		}
         		if (srcImageID == null) {
         			// see if this is a valid image id for a known tag
-        			String tag = deriveImageTag(getTestTag(overrides), srcIS);
+        			String tag = deriveImageTag( srcTag, srcIS);
         			if (tag != null)
-        				srcImageID = getTestStream(overrides) + ":" + tag;
+        				srcImageID = srcStream + ":" + tag;
         		}
         	}
         	
         	if (srcImageID == null) {
-        		listener.getLogger().println(String.format(MessageConstants.EXIT_TAG_NOT_FOUND, getTestTag(overrides), getTestStream(overrides)));
+        		listener.getLogger().println(String.format(MessageConstants.EXIT_TAG_NOT_FOUND, srcTag, srcStream));
         		return false;
         	}
         	
-        	if (chatty)
-        		listener.getLogger().println("\n srcImageID after translation " + srcImageID + " and tag type " + tagType);
-        	
-        	//get dest image stream
-			IImageStream destIS = null;
-			
-			String destinationNS = null;
-			if (getDestinationNamespace(overrides).length() == 0) {
-				destinationNS = getNamespace(overrides);
-			} else {
-				destinationNS = getDestinationNamespace(overrides);
+        	if (chatty) {
+				listener.getLogger().println("\n srcImageID after translation " + srcImageID + " and tag type " + tagType);
 			}
-			
-        	if (getNamespace(overrides).equals(destinationNS) && getTestStream(overrides).equals(getProdStream(overrides))) {
-        		destIS = srcIS;
-        	} else {
-    			try {
-    				// if a dest auth token was set we need to get a base client that uses it, essentially like we just did above 
-    				// for the OpenShiftCreator
-    				if (this.getDestinationAuthToken(overrides) != null && this.getDestinationAuthToken(overrides).length() > 0) {
-    					this.setAuth(Auth.createInstance(chatty ? listener : null, getApiURL(overrides), overrides));
-    					//this.setToken(getDestinationToken());
-    					client = this.getClient(listener, DISPLAY_NAME, overrides, getDestinationAuthToken(overrides));
-    				}
-    				destIS = client.get(ResourceKind.IMAGE_STREAM, getProdStream(overrides), destinationNS);
-    			} catch (com.openshift.restclient.OpenShiftException e) {
-    				String createJson = "{\"kind\": \"ImageStream\",\"apiVersion\": \"v1\",\"metadata\": {\"name\": \"" +
-    				getProdStream(overrides) + "\",\"creationTimestamp\": null},\"spec\": {},\"status\": {\"dockerImageRepository\": \"\"}}";
-    				
-    				Map<String,String> newOverrides = new HashMap<String,String>(overrides);
-    				// we don't want this step's source namespace to be the creator's namespace, but rather this step's destination namespace, so clear out the override and then reuse all other overrides
-    				newOverrides.remove("namespace");
-    				OpenShiftCreator isCreator = new OpenShiftCreator(getApiURL(newOverrides), destinationNS, getDestinationAuthToken(overrides), getVerbose(newOverrides), createJson);
-    				isCreator.setAuth(Auth.createInstance(chatty ? listener : null, getApiURL(newOverrides), overrides));
-    		    	//isCreator.setToken(getDestinationToken());
-    				
-    				
-    				boolean newISCreated = isCreator.coreLogic(launcher, listener, newOverrides);
 
-    				if (!newISCreated) {
-    					listener.getLogger().println(String.format(MessageConstants.EXIT_TAG_CANNOT_CREATE_DEST_IS, getProdStream(overrides), destinationNS));
-    					return false;
-    				}
-    				
-    				destIS = client.get(ResourceKind.IMAGE_STREAM, getProdStream(overrides), destinationNS);
-    			}
-        	}
-        	
-        	if (destIS == null) {
-    			listener.getLogger().println(String.format(MessageConstants.EXIT_TAG_CANNOT_GET_IS, getProdStream(overrides), destinationNS));
-    			return false;
-        	}
-        	
-        	// tag image
-        	destIS.addTag(getProdTag(overrides), tagType, srcImageID, getNamespace(overrides));
-			if (chatty)
-				listener.getLogger().println("\n updated image stream json " + ((ImageStream)destIS).getNode().toJSONString(false));
-			client.update(destIS);
-			
-			
+
+			final IClient destClient;
+
+			// If destination token is set, create a new destination client
+			final String destToken = getDestinationAuthToken(overrides);
+			if ( destToken != null && (!destToken.isEmpty()) ) {
+				this.setAuth(Auth.createInstance(chatty ? listener : null, getApiURL(overrides), overrides));
+				destClient = this.getClient(listener, DISPLAY_NAME, overrides, destToken);
+			} else {
+				destClient = srcClient;
+			}
+
+			List<String> newDestinationStreams = Arrays.asList( destStreams.split( "," ) );
+			List<String> newDestTags = Arrays.asList( destTags.split( "," ) );
+
+			/**
+			 * The following logic is permissive of the following combinations
+			 *  (1) 1 dest stream and 1 dest tag  	(i.e. a single new stream:tag combination)
+			 * 	(2) 1 dest stream and N dest tags   (i.e. all tags apply to the same stream)
+			 * 	(3) 1 dest tag and N dest streams	(i.e. all streams will get the same tag)
+			 * 	(4) N dest streams and N dest tags	(i.e. each index will be a unique stream:tag)
+			 */
+
+			if ( newDestinationStreams.size() != 1 && newDestTags.size() != 1 && newDestinationStreams.size() != newDestTags.size() ) {
+				String error = String.format( "Destination streams (%s) cardinality [%d] is incompatible with destination tag (%s) cardinality [%d]", newDestinationStreams, newDestinationStreams.size(), newDestTags, newDestTags.size() );
+				throw new IllegalArgumentException( error );
+			}
+
+			Iterator<String> iDestStreams = newDestinationStreams.iterator();
+			Iterator<String> iDestTags = newDestTags.iterator();
+			String destStream = null;
+			String destTag = null;
+			while ( iDestStreams.hasNext() || iDestTags.hasNext() ) {
+
+				if ( iDestStreams.hasNext() ) {
+					destStream = iDestStreams.next().trim();
+				}
+
+				if ( iDestTags.hasNext() ) {
+					destTag = iDestTags.next().trim();
+				}
+
+				IImageStream destIS = null;
+				for ( int retries = 10; retries > 0; retries-- ) {
+					try {
+						destIS = destClient.get(ResourceKind.IMAGE_STREAM, destStream, destNS);
+					} catch (com.openshift.restclient.OpenShiftException e) {
+						String createJson = "{\"kind\": \"ImageStream\",\"apiVersion\": \"v1\",\"metadata\": {\"name\": \"" +
+								destStream + "\",\"creationTimestamp\": null},\"spec\": {},\"status\": {\"dockerImageRepository\": \"\"}}";
+
+						Map<String,String> newOverrides = new HashMap<String,String>(overrides);
+						// we don't want this step's source namespace to be the creator's namespace,
+						// but rather this step's destination namespace, so clear out the override
+						// and then reuse all other overrides.
+						newOverrides.remove("namespace");
+
+						String token = destToken;
+						if ( token == null || token.isEmpty() ) {
+							token = getAuthToken();
+						}
+
+						OpenShiftCreator isCreator = new OpenShiftCreator(getApiURL(newOverrides), destNS, token, ""+chatty, createJson);
+						isCreator.setAuth(Auth.createInstance(chatty ? listener : null, getApiURL(newOverrides), overrides));
+
+						boolean newISCreated = isCreator.coreLogic(launcher, listener, newOverrides);
+
+						if (!newISCreated) {
+							listener.getLogger().println(String.format(MessageConstants.EXIT_TAG_CANNOT_CREATE_DEST_IS, destStream, destNS));
+							return false;
+						}
+
+						destIS = srcClient.get(ResourceKind.IMAGE_STREAM, destStream, destNS);
+					}
+
+					if (destIS == null) {
+						listener.getLogger().println(String.format(MessageConstants.EXIT_TAG_CANNOT_GET_IS, destStream, destNS));
+						return false;
+					}
+
+					destIS.addTag( destTag, tagType, srcImageID, srcNS);
+					if (chatty) {
+						listener.getLogger().println("\n updated image stream json " + ((ImageStream) destIS).getNode().toJSONString(false) + " with tag: " + destTag );
+					}
+
+					try {
+						destClient.update(destIS);
+						break;
+					} catch ( OpenShiftException ose ) {
+						if ( ose.getStatus().getCode() == 403 && retries > 1 ) { // If resource was updating, retry
+							continue;
+						}
+						throw ose;
+					}
+				}
+			}
+
 	    	listener.getLogger().println(String.format(MessageConstants.EXIT_OK, DISPLAY_NAME));
 			return true;
     	} else {

--- a/src/main/resources/com/openshift/jenkins/plugins/pipeline/OpenShiftImageTagger/help-prodStream.html
+++ b/src/main/resources/com/openshift/jenkins/plugins/pipeline/OpenShiftImageTagger/help-prodStream.html
@@ -1,3 +1,5 @@
 <div>
-  The name of the ImagStream for the new tag name.
+  One or more ImageStream names in a comma delimited list. If multiple
+  streams and multiple destination tags are specified, the two lists
+  must contain the same number of elements.
 </div>

--- a/src/main/resources/com/openshift/jenkins/plugins/pipeline/OpenShiftImageTagger/help-prodTag.html
+++ b/src/main/resources/com/openshift/jenkins/plugins/pipeline/OpenShiftImageTagger/help-prodTag.html
@@ -1,3 +1,5 @@
 <div>
-  The name of the new tag to be applied to the image.
+  One or more tag names in a comma delimited list. If multiple
+  streams and multiple destination tags are specified, the two lists
+  must contain the same number of elements.
 </div>


### PR DESCRIPTION
Adding exec function for card:
https://trello.com/c/Yl4qomsw/878-5-additional-jenkins-plugin-enhancement-requests-from-github

ptal @gabemontero @bparees 

Enabling the following forms:
1. 1 destination stream and 1 destination tag   (i.e. single tag applies to single stream)
2. 1 destination stream and N destination tags   (i.e. all tags apply to the same stream)
3. 1 destination tag and N destination streams  (i.e. all streams will get the same tag)
4. N destination streams and N destination tags (i.e. each index will be combined to form a unique stream:tag combination)
