### PR TITLE
Timeout fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ Optional parameters are:
 - "env": An array of environment variables for the build (e.g. `env : [ [ name : 'name1', value : 'value1' ], [ name : 'name2', value : 'value2' ] ]`.
 - "showBuildLogs":  Pipe the build logs from OpenShift to the Jenkins console.
 - "checkForTriggeredDeployments":  Verify whether any deployments triggered by this build's output fired.
-- "waitTime":  Time in milliseconds to wait for build completion.  Default is 5 minutes.
+- "waitTime":  Time in milliseconds to wait for build completion.  Default is 15 minutes.
 
 #### "Trigger OpenShift Deployment"
 
@@ -129,7 +129,7 @@ The step name is "openshiftDeploy".  Mandatory parameters are:
 
 Optional parameters are:
 
--  "waitTime":  Time in milliseconds to wait for deployment completion.  Default is 1 minute.
+-  "waitTime":  Time in milliseconds to wait for deployment completion.  Default is 10 minutes.
 
 #### "Run OpenShift Exec"
 
@@ -142,7 +142,7 @@ Optional parameters are:
 
 - "container" : The container name in which to run the command. If not specified, the first container in the pod will be used.
 -  "arguments" : Arguments for the command. May be specified as `arguments: [ 'arg1', 'arg2', ... ]` or `arguments: [ [ value: 'arg1' ], [ value : 'arg2' ], ... ]` 
--  "waitTime" :  Time in milliseconds to wait for deployment completion.  Default is 1 minute.
+-  "waitTime" :  Time in milliseconds to wait for deployment completion.  Default is 3 minutes.
 
 #### "Create OpenShift Resource(s)"
 
@@ -243,7 +243,7 @@ Optional parameters are:
 
 - "verifyReplicaCount":  Verify whether the specified number of replicas are up.  Specify `true` or `false`.
 
-- "waitTime":  The amount of time in milliseconds to see whether the specified number of replicas have been reached.  Default is 1 minute.
+- "waitTime":  The amount of time in milliseconds to see whether the specified number of replicas have been reached.  Default is 3 minutes.
 
 ####  "Verify OpenShift Service"
 

--- a/src/main/java/com/openshift/jenkins/plugins/pipeline/OpenShiftBasePostAction.java
+++ b/src/main/java/com/openshift/jenkins/plugins/pipeline/OpenShiftBasePostAction.java
@@ -1,12 +1,6 @@
 package com.openshift.jenkins.plugins.pipeline;
 
-import java.io.IOException;
-import java.io.Serializable;
-
 import com.openshift.jenkins.plugins.pipeline.model.IOpenShiftPlugin;
-//import com.openshift.restclient.authorization.TokenAuthorizationStrategy;
-
-import jenkins.tasks.SimpleBuildStep;
 import hudson.FilePath;
 import hudson.Launcher;
 import hudson.model.AbstractBuild;
@@ -15,6 +9,10 @@ import hudson.model.Run;
 import hudson.model.TaskListener;
 import hudson.tasks.BuildStepMonitor;
 import hudson.tasks.Recorder;
+import jenkins.tasks.SimpleBuildStep;
+
+import java.io.IOException;
+import java.io.Serializable;
 
 public abstract class OpenShiftBasePostAction extends Recorder implements SimpleBuildStep, Serializable, IOpenShiftPlugin {
 
@@ -22,7 +20,6 @@ public abstract class OpenShiftBasePostAction extends Recorder implements Simple
     protected final String namespace;
     protected final String authToken;
     protected final String verbose;
-    //protected transient TokenAuthorizationStrategy bearerToken;
     protected transient Auth auth;
 
     public OpenShiftBasePostAction(String apiURL, String namespace, String authToken, String verbose) {
@@ -58,21 +55,11 @@ public abstract class OpenShiftBasePostAction extends Recorder implements Simple
 		this.auth = auth;
 	}
 
-/*	@Override
-	public void setToken(TokenAuthorizationStrategy token) {
-		this.bearerToken = token;
-	}
-*/    
     @Override
 	public Auth getAuth() {
 		return auth;
 	}
 
-/*	@Override
-	public TokenAuthorizationStrategy getToken() {
-		return bearerToken;
-	}
-*/
 	@Override
 	public String getBaseClassName() {
 		return OpenShiftBasePostAction.class.getName();

--- a/src/main/java/com/openshift/jenkins/plugins/pipeline/OpenShiftBaseStep.java
+++ b/src/main/java/com/openshift/jenkins/plugins/pipeline/OpenShiftBaseStep.java
@@ -1,19 +1,19 @@
 package com.openshift.jenkins.plugins.pipeline;
 
-import java.io.IOException;
-import java.io.Serializable;
-
 import com.openshift.jenkins.plugins.pipeline.model.IOpenShiftPlugin;
-//import com.openshift.restclient.authorization.TokenAuthorizationStrategy;
-
-import jenkins.tasks.SimpleBuildStep;
 import hudson.FilePath;
 import hudson.Launcher;
 import hudson.model.AbstractBuild;
 import hudson.model.BuildListener;
-import hudson.model.TaskListener;
 import hudson.model.Run;
+import hudson.model.TaskListener;
 import hudson.tasks.Builder;
+import jenkins.tasks.SimpleBuildStep;
+
+import java.io.IOException;
+import java.io.Serializable;
+
+//import com.openshift.restclient.authorization.TokenAuthorizationStrategy;
 
 public abstract class OpenShiftBaseStep extends Builder  implements SimpleBuildStep, Serializable, IOpenShiftPlugin {
 	
@@ -63,16 +63,6 @@ public abstract class OpenShiftBaseStep extends Builder  implements SimpleBuildS
 		return auth;
 	}
 	
-/*	@Override
-	public TokenAuthorizationStrategy getToken() {
-		return bearerToken;
-	}
-
-	@Override
-	public void setToken(TokenAuthorizationStrategy token) {
-		this.bearerToken = token;
-	}
-*/
 	@Override
 	public String getBaseClassName() {
 		return OpenShiftBaseStep.class.getName();

--- a/src/main/java/com/openshift/jenkins/plugins/pipeline/OpenShiftBuildCanceller.java
+++ b/src/main/java/com/openshift/jenkins/plugins/pipeline/OpenShiftBuildCanceller.java
@@ -1,4 +1,5 @@
 package com.openshift.jenkins.plugins.pipeline;
+import com.openshift.jenkins.plugins.pipeline.model.IOpenShiftPluginDescriptorValidation;
 import hudson.Launcher;
 import hudson.Extension;
 import hudson.util.FormValidation;
@@ -118,7 +119,7 @@ public class OpenShiftBuildCanceller extends OpenShiftBasePostAction {
      *
      */
     @Extension // This indicates to Jenkins that this is an implementation of an extension point.
-    public static final class DescriptorImpl extends BuildStepDescriptor<Publisher> {
+    public static final class DescriptorImpl extends BuildStepDescriptor<Publisher> implements IOpenShiftPluginDescriptorValidation {
         /**
          * To persist global configuration information,
          * simply store it in a field and call save().
@@ -135,36 +136,10 @@ public class OpenShiftBuildCanceller extends OpenShiftBasePostAction {
             load();
         }
 
-        /**
-         * Performs on-the-fly validation of the various fields.
-         *
-         * @param value
-         *      This parameter receives the value that the user has typed.
-         * @return
-         *      Indicates the outcome of the validation. This is sent to the browser.
-         *      <p>
-         *      Note that returning {@link FormValidation#error(String)} does not
-         *      prevent the form from being saved. It just means that a message
-         *      will be displayed to the user. 
-         */
-        public FormValidation doCheckApiURL(@QueryParameter String value)
-                throws IOException, ServletException {
-        	return ParamVerify.doCheckApiURL(value);
-        }
 
         public FormValidation doCheckBldCfg(@QueryParameter String value)
                 throws IOException, ServletException {
         	return ParamVerify.doCheckBldCfg(value);
-        }
-
-        public FormValidation doCheckNamespace(@QueryParameter String value)
-                throws IOException, ServletException {
-        	return ParamVerify.doCheckNamespace(value);
-        }
-        
-        public FormValidation doCheckAuthToken(@QueryParameter String value)
-                throws IOException, ServletException {
-        	return ParamVerify.doCheckToken(value);
         }
 
         public boolean isApplicable(Class<? extends AbstractProject> aClass) {

--- a/src/main/java/com/openshift/jenkins/plugins/pipeline/OpenShiftBuildVerifier.java
+++ b/src/main/java/com/openshift/jenkins/plugins/pipeline/OpenShiftBuildVerifier.java
@@ -1,34 +1,31 @@
 package com.openshift.jenkins.plugins.pipeline;
-import hudson.Extension;
-import hudson.util.FormValidation;
-import hudson.model.AbstractProject;
-import hudson.tasks.Builder;
-import hudson.tasks.BuildStepDescriptor;
-import net.sf.json.JSONObject;
-
-import org.kohsuke.stapler.DataBoundConstructor;
-import org.kohsuke.stapler.StaplerRequest;
-import org.kohsuke.stapler.QueryParameter;
 
 import com.openshift.jenkins.plugins.pipeline.model.GlobalConfig;
 import com.openshift.jenkins.plugins.pipeline.model.IOpenShiftBuildVerifier;
+import com.openshift.jenkins.plugins.pipeline.model.IOpenShiftPluginDescriptorValidation;
+import hudson.Extension;
+import hudson.model.AbstractProject;
+import hudson.tasks.BuildStepDescriptor;
+import hudson.tasks.Builder;
+import hudson.util.FormValidation;
+import net.sf.json.JSONObject;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.QueryParameter;
+import org.kohsuke.stapler.StaplerRequest;
 
 import javax.servlet.ServletException;
-
 import java.io.IOException;
-import java.util.Map;
 
 
-public class OpenShiftBuildVerifier extends OpenShiftBaseStep implements IOpenShiftBuildVerifier {
+public class OpenShiftBuildVerifier extends TimedOpenShiftBaseStep implements IOpenShiftBuildVerifier {
 	
     protected final String bldCfg;
     protected final String checkForTriggeredDeployments;
-    protected String waitTime; //TODO include in constructor / config.jelly
-    
+
     // Fields in config.jelly must match the parameter names in the "DataBoundConstructor"
     @DataBoundConstructor
-    public OpenShiftBuildVerifier(String apiURL, String bldCfg, String namespace, String authToken, String verbose, String checkForTriggeredDeployments) {
-    	super(apiURL, namespace, authToken, verbose);
+    public OpenShiftBuildVerifier(String apiURL, String bldCfg, String namespace, String authToken, String verbose, String checkForTriggeredDeployments, String waitTime) {
+    	super(apiURL, namespace, authToken, verbose, waitTime);
         this.bldCfg = bldCfg;
         this.checkForTriggeredDeployments = checkForTriggeredDeployments;
     }
@@ -46,18 +43,6 @@ public class OpenShiftBuildVerifier extends OpenShiftBaseStep implements IOpenSh
 		return checkForTriggeredDeployments;
 	}
 	
-	public String getWaitTime() {
-		return waitTime;
-	}
-	
-	public String getWaitTime(Map<String,String> overrides) {
-		String val = getOverride(getWaitTime(), overrides);
-		if (val.length() > 0)
-			return val;
-		return Long.toString(getDescriptor().getWait());
-	}
-	
-	
 	// Overridden for better type safety.
     // If your plugin doesn't really define any property on Descriptor,
     // you don't have to do this.
@@ -72,59 +57,15 @@ public class OpenShiftBuildVerifier extends OpenShiftBaseStep implements IOpenSh
      *
      */
     @Extension // This indicates to Jenkins that this is an implementation of an extension point.
-    public static final class DescriptorImpl extends BuildStepDescriptor<Builder> {
-    	private long wait = GlobalConfig.BUILD_VERIFY_WAIT;
-        /**
-         * To persist global configuration information,
-         * simply store it in a field and call save().
-         *
-         * <p>
-         * If you don't want fields to be persisted, use <tt>transient</tt>.
-         */
+    public static final class DescriptorImpl extends BuildStepDescriptor<Builder> implements IOpenShiftPluginDescriptorValidation {
 
-        /**
-         * In order to load the persisted global configuration, you have to 
-         * call load() in the constructor.
-         */
         public DescriptorImpl() {
             load();
-        }
-
-        /**
-         * Performs on-the-fly validation of the various fields.
-         *
-         * @param value
-         *      This parameter receives the value that the user has typed.
-         * @return
-         *      Indicates the outcome of the validation. This is sent to the browser.
-         *      <p>
-         *      Note that returning {@link FormValidation#error(String)} does not
-         *      prevent the form from being saved. It just means that a message
-         *      will be displayed to the user. 
-         */
-        public FormValidation doCheckApiURL(@QueryParameter String value)
-                throws IOException, ServletException {
-        	return ParamVerify.doCheckApiURL(value);
         }
 
         public FormValidation doCheckBldCfg(@QueryParameter String value)
                 throws IOException, ServletException {
         	return ParamVerify.doCheckBldCfg(value);
-        }
-
-        public FormValidation doCheckNamespace(@QueryParameter String value)
-                throws IOException, ServletException {
-        	return ParamVerify.doCheckNamespace(value);
-        }
-        
-        public FormValidation doCheckCheckForTriggeredDeployments(@QueryParameter String value)
-                throws IOException, ServletException {
-        	return ParamVerify.doCheckCheckForTriggeredDeployments(value);
-        }
-        
-        public FormValidation doCheckAuthToken(@QueryParameter String value)
-                throws IOException, ServletException {
-        	return ParamVerify.doCheckToken(value);
         }
 
         public boolean isApplicable(Class<? extends AbstractProject> aClass) {
@@ -139,16 +80,11 @@ public class OpenShiftBuildVerifier extends OpenShiftBaseStep implements IOpenSh
             return DISPLAY_NAME;
         }
         
-        public long getWait() {
-        	return wait;
-        }
-
         @Override
         public boolean configure(StaplerRequest req, JSONObject formData) throws FormException {
             // To persist global configuration information,
             // pull info from formData, set appropriate instance field (which should have a getter), and call save().
-        	wait = formData.getLong("wait");
-        	GlobalConfig.setBuildVerifyWait(wait);
+        	GlobalConfig.setBuildVerifyWait(formData.getLong("wait"));
             save();
             return super.configure(req,formData);
         }

--- a/src/main/java/com/openshift/jenkins/plugins/pipeline/OpenShiftCreator.java
+++ b/src/main/java/com/openshift/jenkins/plugins/pipeline/OpenShiftCreator.java
@@ -1,19 +1,18 @@
 package com.openshift.jenkins.plugins.pipeline;
-import hudson.Extension;
-import hudson.util.FormValidation;
-import hudson.model.AbstractProject;
-import hudson.tasks.Builder;
-import hudson.tasks.BuildStepDescriptor;
-import net.sf.json.JSONObject;
-
-import org.kohsuke.stapler.DataBoundConstructor;
-import org.kohsuke.stapler.StaplerRequest;
-import org.kohsuke.stapler.QueryParameter;
 
 import com.openshift.jenkins.plugins.pipeline.model.IOpenShiftCreator;
+import com.openshift.jenkins.plugins.pipeline.model.IOpenShiftPluginDescriptorValidation;
+import hudson.Extension;
+import hudson.model.AbstractProject;
+import hudson.tasks.BuildStepDescriptor;
+import hudson.tasks.Builder;
+import hudson.util.FormValidation;
+import net.sf.json.JSONObject;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.QueryParameter;
+import org.kohsuke.stapler.StaplerRequest;
 
 import javax.servlet.ServletException;
-
 import java.io.IOException;
 
 
@@ -52,7 +51,7 @@ public class OpenShiftCreator extends OpenShiftBaseStep implements IOpenShiftCre
      *
      */
     @Extension // This indicates to Jenkins that this is an implementation of an extension point.
-    public static final class DescriptorImpl extends BuildStepDescriptor<Builder> {
+    public static final class DescriptorImpl extends BuildStepDescriptor<Builder> implements IOpenShiftPluginDescriptorValidation {
         /**
          * To persist global configuration information,
          * simply store it in a field and call save().
@@ -69,36 +68,10 @@ public class OpenShiftCreator extends OpenShiftBaseStep implements IOpenShiftCre
             load();
         }
 
-        /**
-         * Performs on-the-fly validation of the various fields.
-         *
-         * @param value
-         *      This parameter receives the value that the user has typed.
-         * @return
-         *      Indicates the outcome of the validation. This is sent to the browser.
-         *      <p>
-         *      Note that returning {@link FormValidation#error(String)} does not
-         *      prevent the form from being saved. It just means that a message
-         *      will be displayed to the user. 
-         */
-        public FormValidation doCheckApiURL(@QueryParameter String value)
-                throws IOException, ServletException {
-        	return ParamVerify.doCheckApiURL(value);
-        }
-
-        public FormValidation doCheckNamespace(@QueryParameter String value)
-                throws IOException, ServletException {
-        	return ParamVerify.doCheckNamespace(value);
-        }
 
         public FormValidation doCheckJsonyaml(@QueryParameter String value)
                 throws IOException, ServletException {
         	return ParamVerify.doCheckJsonyaml(value);
-        }
-
-        public FormValidation doCheckAuthToken(@QueryParameter String value)
-                throws IOException, ServletException {
-        	return ParamVerify.doCheckToken(value);
         }
 
         public boolean isApplicable(Class<? extends AbstractProject> aClass) {

--- a/src/main/java/com/openshift/jenkins/plugins/pipeline/OpenShiftDeleterJsonYaml.java
+++ b/src/main/java/com/openshift/jenkins/plugins/pipeline/OpenShiftDeleterJsonYaml.java
@@ -1,19 +1,18 @@
 package com.openshift.jenkins.plugins.pipeline;
-import hudson.Extension;
-import hudson.util.FormValidation;
-import hudson.model.AbstractProject;
-import hudson.tasks.Builder;
-import hudson.tasks.BuildStepDescriptor;
-import net.sf.json.JSONObject;
-
-import org.kohsuke.stapler.DataBoundConstructor;
-import org.kohsuke.stapler.StaplerRequest;
-import org.kohsuke.stapler.QueryParameter;
 
 import com.openshift.jenkins.plugins.pipeline.model.IOpenShiftDeleterJsonYaml;
+import com.openshift.jenkins.plugins.pipeline.model.IOpenShiftPluginDescriptorValidation;
+import hudson.Extension;
+import hudson.model.AbstractProject;
+import hudson.tasks.BuildStepDescriptor;
+import hudson.tasks.Builder;
+import hudson.util.FormValidation;
+import net.sf.json.JSONObject;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.QueryParameter;
+import org.kohsuke.stapler.StaplerRequest;
 
 import javax.servlet.ServletException;
-
 import java.io.IOException;
 
 
@@ -52,7 +51,7 @@ public class OpenShiftDeleterJsonYaml extends OpenShiftBaseStep implements IOpen
      *
      */
     @Extension // This indicates to Jenkins that this is an implementation of an extension point.
-    public static final class DescriptorImpl extends BuildStepDescriptor<Builder> {
+    public static final class DescriptorImpl extends BuildStepDescriptor<Builder> implements IOpenShiftPluginDescriptorValidation {
         /**
          * To persist global configuration information,
          * simply store it in a field and call save().
@@ -69,36 +68,10 @@ public class OpenShiftDeleterJsonYaml extends OpenShiftBaseStep implements IOpen
             load();
         }
 
-        /**
-         * Performs on-the-fly validation of the various fields.
-         *
-         * @param value
-         *      This parameter receives the value that the user has typed.
-         * @return
-         *      Indicates the outcome of the validation. This is sent to the browser.
-         *      <p>
-         *      Note that returning {@link FormValidation#error(String)} does not
-         *      prevent the form from being saved. It just means that a message
-         *      will be displayed to the user. 
-         */
-        public FormValidation doCheckApiURL(@QueryParameter String value)
-                throws IOException, ServletException {
-        	return ParamVerify.doCheckApiURL(value);
-        }
-
-        public FormValidation doCheckNamespace(@QueryParameter String value)
-                throws IOException, ServletException {
-        	return ParamVerify.doCheckNamespace(value);
-        }
 
         public FormValidation doCheckJsonyaml(@QueryParameter String value)
                 throws IOException, ServletException {
         	return ParamVerify.doCheckJsonyaml(value);
-        }
-
-        public FormValidation doCheckAuthToken(@QueryParameter String value)
-                throws IOException, ServletException {
-        	return ParamVerify.doCheckToken(value);
         }
 
         public boolean isApplicable(Class<? extends AbstractProject> aClass) {

--- a/src/main/java/com/openshift/jenkins/plugins/pipeline/OpenShiftDeleterLabels.java
+++ b/src/main/java/com/openshift/jenkins/plugins/pipeline/OpenShiftDeleterLabels.java
@@ -1,5 +1,7 @@
 package com.openshift.jenkins.plugins.pipeline;
 
+import com.openshift.jenkins.plugins.pipeline.model.IOpenShiftDeleterLabels;
+import com.openshift.jenkins.plugins.pipeline.model.IOpenShiftPluginDescriptorValidation;
 import hudson.Extension;
 import hudson.model.AbstractProject;
 import hudson.model.Item;
@@ -7,19 +9,14 @@ import hudson.tasks.BuildStepDescriptor;
 import hudson.tasks.Builder;
 import hudson.util.FormValidation;
 import hudson.util.ListBoxModel;
-
-import java.io.IOException;
-
-import javax.servlet.ServletException;
-
 import net.sf.json.JSONObject;
-
 import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.StaplerRequest;
 
-import com.openshift.jenkins.plugins.pipeline.model.IOpenShiftDeleterLabels;
+import javax.servlet.ServletException;
+import java.io.IOException;
 
 
 public class OpenShiftDeleterLabels extends OpenShiftBaseStep implements IOpenShiftDeleterLabels {
@@ -68,7 +65,7 @@ public class OpenShiftDeleterLabels extends OpenShiftBaseStep implements IOpenSh
      *
      */
     @Extension // This indicates to Jenkins that this is an implementation of an extension point.
-    public static final class DescriptorImpl extends BuildStepDescriptor<Builder> {
+    public static final class DescriptorImpl extends BuildStepDescriptor<Builder> implements IOpenShiftPluginDescriptorValidation {
         /**
          * To persist global configuration information,
          * simply store it in a field and call save().
@@ -83,28 +80,6 @@ public class OpenShiftDeleterLabels extends OpenShiftBaseStep implements IOpenSh
          */
         public DescriptorImpl() {
             load();
-        }
-
-        /**
-         * Performs on-the-fly validation of the various fields.
-         *
-         * @param value
-         *      This parameter receives the value that the user has typed.
-         * @return
-         *      Indicates the outcome of the validation. This is sent to the browser.
-         *      <p>
-         *      Note that returning {@link FormValidation#error(String)} does not
-         *      prevent the form from being saved. It just means that a message
-         *      will be displayed to the user. 
-         */
-        public FormValidation doCheckApiURL(@QueryParameter String value)
-                throws IOException, ServletException {
-        	return ParamVerify.doCheckApiURL(value);
-        }
-
-        public FormValidation doCheckNamespace(@QueryParameter String value)
-                throws IOException, ServletException {
-        	return ParamVerify.doCheckNamespace(value);
         }
 
         public FormValidation doCheckType(@QueryParameter String value)
@@ -125,10 +100,6 @@ public class OpenShiftDeleterLabels extends OpenShiftBaseStep implements IOpenSh
         	return ret;
         }
 
-        public FormValidation doCheckAuthToken(@QueryParameter String value)
-                throws IOException, ServletException {
-        	return ParamVerify.doCheckToken(value);
-        }
 
         public boolean isApplicable(Class<? extends AbstractProject> aClass) {
             // Indicates that this builder can be used with all kinds of project types 

--- a/src/main/java/com/openshift/jenkins/plugins/pipeline/OpenShiftDeleterList.java
+++ b/src/main/java/com/openshift/jenkins/plugins/pipeline/OpenShiftDeleterList.java
@@ -1,5 +1,7 @@
 package com.openshift.jenkins.plugins.pipeline;
 
+import com.openshift.jenkins.plugins.pipeline.model.IOpenShiftDeleterList;
+import com.openshift.jenkins.plugins.pipeline.model.IOpenShiftPluginDescriptorValidation;
 import hudson.Extension;
 import hudson.model.AbstractProject;
 import hudson.model.Item;
@@ -7,19 +9,14 @@ import hudson.tasks.BuildStepDescriptor;
 import hudson.tasks.Builder;
 import hudson.util.FormValidation;
 import hudson.util.ListBoxModel;
-
-import java.io.IOException;
-
-import javax.servlet.ServletException;
-
 import net.sf.json.JSONObject;
-
 import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.StaplerRequest;
 
-import com.openshift.jenkins.plugins.pipeline.model.IOpenShiftDeleterList;
+import javax.servlet.ServletException;
+import java.io.IOException;
 
 public class OpenShiftDeleterList extends OpenShiftBaseStep implements IOpenShiftDeleterList {
 
@@ -61,7 +58,7 @@ public class OpenShiftDeleterList extends OpenShiftBaseStep implements IOpenShif
      *
      */
     @Extension // This indicates to Jenkins that this is an implementation of an extension point.
-    public static final class DescriptorImpl extends BuildStepDescriptor<Builder> {
+    public static final class DescriptorImpl extends BuildStepDescriptor<Builder> implements IOpenShiftPluginDescriptorValidation {
         /**
          * To persist global configuration information,
          * simply store it in a field and call save().
@@ -76,28 +73,6 @@ public class OpenShiftDeleterList extends OpenShiftBaseStep implements IOpenShif
          */
         public DescriptorImpl() {
             load();
-        }
-
-        /**
-         * Performs on-the-fly validation of the various fields.
-         *
-         * @param value
-         *      This parameter receives the value that the user has typed.
-         * @return
-         *      Indicates the outcome of the validation. This is sent to the browser.
-         *      <p>
-         *      Note that returning {@link FormValidation#error(String)} does not
-         *      prevent the form from being saved. It just means that a message
-         *      will be displayed to the user. 
-         */
-        public FormValidation doCheckApiURL(@QueryParameter String value)
-                throws IOException, ServletException {
-        	return ParamVerify.doCheckApiURL(value);
-        }
-
-        public FormValidation doCheckNamespace(@QueryParameter String value)
-                throws IOException, ServletException {
-        	return ParamVerify.doCheckNamespace(value);
         }
 
         public FormValidation doCheckType(@QueryParameter String value)
@@ -116,11 +91,6 @@ public class OpenShiftDeleterList extends OpenShiftBaseStep implements IOpenShif
         	ret.add("API Object type : API Object key", "kv");
         	ret.add("Label", "label");
         	return ret;
-        }
-
-        public FormValidation doCheckAuthToken(@QueryParameter String value)
-                throws IOException, ServletException {
-        	return ParamVerify.doCheckToken(value);
         }
 
         public boolean isApplicable(Class<? extends AbstractProject> aClass) {

--- a/src/main/java/com/openshift/jenkins/plugins/pipeline/OpenShiftDeployCanceller.java
+++ b/src/main/java/com/openshift/jenkins/plugins/pipeline/OpenShiftDeployCanceller.java
@@ -1,24 +1,23 @@
 package com.openshift.jenkins.plugins.pipeline;
-import hudson.Launcher;
-import hudson.Extension;
-import hudson.util.FormValidation;
-import hudson.model.TaskListener;
-import hudson.model.AbstractProject;
-import hudson.tasks.BuildStepDescriptor;
-import hudson.tasks.Publisher;
-import net.sf.json.JSONObject;
 
-import org.kohsuke.stapler.DataBoundConstructor;
-import org.kohsuke.stapler.StaplerRequest;
-import org.kohsuke.stapler.QueryParameter;
-
+import com.openshift.jenkins.plugins.pipeline.model.IOpenShiftPluginDescriptorValidation;
 import com.openshift.restclient.IClient;
 import com.openshift.restclient.ResourceKind;
 import com.openshift.restclient.model.IDeploymentConfig;
 import com.openshift.restclient.model.IReplicationController;
+import hudson.Extension;
+import hudson.Launcher;
+import hudson.model.AbstractProject;
+import hudson.model.TaskListener;
+import hudson.tasks.BuildStepDescriptor;
+import hudson.tasks.Publisher;
+import hudson.util.FormValidation;
+import net.sf.json.JSONObject;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.QueryParameter;
+import org.kohsuke.stapler.StaplerRequest;
 
 import javax.servlet.ServletException;
-
 import java.io.IOException;
 import java.util.Map;
 
@@ -117,7 +116,7 @@ public class OpenShiftDeployCanceller extends OpenShiftBasePostAction {
      *
      */
     @Extension // This indicates to Jenkins that this is an implementation of an extension point.
-    public static final class DescriptorImpl extends BuildStepDescriptor<Publisher> {
+    public static final class DescriptorImpl extends BuildStepDescriptor<Publisher> implements IOpenShiftPluginDescriptorValidation {
         /**
          * To persist global configuration information,
          * simply store it in a field and call save().
@@ -134,36 +133,10 @@ public class OpenShiftDeployCanceller extends OpenShiftBasePostAction {
             load();
         }
 
-        /**
-         * Performs on-the-fly validation of the various fields.
-         *
-         * @param value
-         *      This parameter receives the value that the user has typed.
-         * @return
-         *      Indicates the outcome of the validation. This is sent to the browser.
-         *      <p>
-         *      Note that returning {@link FormValidation#error(String)} does not
-         *      prevent the form from being saved. It just means that a message
-         *      will be displayed to the user. 
-         */
-        public FormValidation doCheckApiURL(@QueryParameter String value)
-                throws IOException, ServletException {
-        	return ParamVerify.doCheckApiURL(value);
-        }
 
         public FormValidation doCheckDepCfg(@QueryParameter String value)
                 throws IOException, ServletException {
         	return ParamVerify.doCheckDepCfg(value);
-        }
-
-        public FormValidation doCheckNamespace(@QueryParameter String value)
-                throws IOException, ServletException {
-        	return ParamVerify.doCheckNamespace(value);
-        }
-        
-        public FormValidation doCheckAuthToken(@QueryParameter String value)
-                throws IOException, ServletException {
-        	return ParamVerify.doCheckToken(value);
         }
 
         public boolean isApplicable(Class<? extends AbstractProject> aClass) {

--- a/src/main/java/com/openshift/jenkins/plugins/pipeline/OpenShiftDeployer.java
+++ b/src/main/java/com/openshift/jenkins/plugins/pipeline/OpenShiftDeployer.java
@@ -1,37 +1,30 @@
 package com.openshift.jenkins.plugins.pipeline;
 
-import java.io.IOException;
-import java.util.Map;
-
-import javax.servlet.ServletException;
-
-import net.sf.json.JSONObject;
-
-import org.kohsuke.stapler.DataBoundConstructor;
-import org.kohsuke.stapler.QueryParameter;
-import org.kohsuke.stapler.StaplerRequest;
-
 import com.openshift.jenkins.plugins.pipeline.model.GlobalConfig;
 import com.openshift.jenkins.plugins.pipeline.model.IOpenShiftDeployer;
-
+import com.openshift.jenkins.plugins.pipeline.model.IOpenShiftPluginDescriptorValidation;
 import hudson.Extension;
 import hudson.model.AbstractProject;
 import hudson.tasks.BuildStepDescriptor;
 import hudson.tasks.Builder;
 import hudson.util.FormValidation;
+import net.sf.json.JSONObject;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.QueryParameter;
+import org.kohsuke.stapler.StaplerRequest;
 
-public class OpenShiftDeployer extends OpenShiftBaseStep implements IOpenShiftDeployer {
+import javax.servlet.ServletException;
+import java.io.IOException;
+
+public class OpenShiftDeployer extends TimedOpenShiftBaseStep implements IOpenShiftDeployer {
 	
     protected final String depCfg;    
-    protected final String waitTime;
-    
-    
+
     // Fields in config.jelly must match the parameter names in the "DataBoundConstructor"
     @DataBoundConstructor
     public OpenShiftDeployer(String apiURL, String depCfg, String namespace, String authToken, String verbose, String waitTime) {
-    	super(apiURL, namespace, authToken, verbose);
+    	super(apiURL, namespace, authToken, verbose, waitTime);
         this.depCfg = depCfg;
-        this.waitTime = waitTime;
     }
 
     // generically speaking, Jenkins will always pass in non-null field values.  However, as we have periodically
@@ -43,17 +36,6 @@ public class OpenShiftDeployer extends OpenShiftBaseStep implements IOpenShiftDe
 		return depCfg;
 	}
 
-	public String getWaitTime() {
-		return waitTime;
-	}
-	
-	public String getWaitTime(Map<String, String> overrides) {
-		String val = getOverride(getWaitTime(), overrides);
-		if (val.length() > 0)
-			return val;
-		return Long.toString(getDescriptor().getWait());
-	}
-	
     // Overridden for better type safety.
     // If your plugin doesn't really define any property on Descriptor,
     // you don't have to do this.
@@ -68,8 +50,7 @@ public class OpenShiftDeployer extends OpenShiftBaseStep implements IOpenShiftDe
      *
      */
     @Extension // This indicates to Jenkins that this is an implementation of an extension point.
-    public static final class DescriptorImpl extends BuildStepDescriptor<Builder> {
-    	private long wait = GlobalConfig.DEPLOY_WAIT;
+    public static final class DescriptorImpl extends BuildStepDescriptor<Builder> implements IOpenShiftPluginDescriptorValidation {
         /**
          * To persist global configuration information,
          * simply store it in a field and call save().
@@ -86,36 +67,9 @@ public class OpenShiftDeployer extends OpenShiftBaseStep implements IOpenShiftDe
             load();
         }
 
-        /**
-         * Performs on-the-fly validation of the various fields.
-         *
-         * @param value
-         *      This parameter receives the value that the user has typed.
-         * @return
-         *      Indicates the outcome of the validation. This is sent to the browser.
-         *      <p>
-         *      Note that returning {@link FormValidation#error(String)} does not
-         *      prevent the form from being saved. It just means that a message
-         *      will be displayed to the user. 
-         */
-        public FormValidation doCheckApiURL(@QueryParameter String value)
-                throws IOException, ServletException {
-        	return ParamVerify.doCheckApiURL(value);
-        }
-
         public FormValidation doCheckDepCfg(@QueryParameter String value)
                 throws IOException, ServletException {
         	return ParamVerify.doCheckDepCfg(value);
-        }
-
-        public FormValidation doCheckNamespace(@QueryParameter String value)
-                throws IOException, ServletException {
-        	return ParamVerify.doCheckNamespace(value);
-        }
-        
-        public FormValidation doCheckAuthToken(@QueryParameter String value)
-                throws IOException, ServletException {
-        	return ParamVerify.doCheckToken(value);
         }
 
         public boolean isApplicable(Class<? extends AbstractProject> aClass) {
@@ -130,16 +84,11 @@ public class OpenShiftDeployer extends OpenShiftBaseStep implements IOpenShiftDe
             return DISPLAY_NAME;
         }
         
-        public long getWait() {
-        	return wait;
-        }
-
         @Override
         public boolean configure(StaplerRequest req, JSONObject formData) throws FormException {
             // To persist global configuration information,
             // pull info from formData, set appropriate instance field (which should have a getter), and call save().
-        	wait = formData.getLong("wait");
-        	GlobalConfig.setDeployWait(wait);
+        	GlobalConfig.setDeployWait(formData.getLong("wait"));
             save();
             return super.configure(req,formData);
         }

--- a/src/main/java/com/openshift/jenkins/plugins/pipeline/OpenShiftImageStreams.java
+++ b/src/main/java/com/openshift/jenkins/plugins/pipeline/OpenShiftImageStreams.java
@@ -1,41 +1,35 @@
 package com.openshift.jenkins.plugins.pipeline;
 
-import java.io.File;
-import java.io.IOException;
-import java.util.Map;
-
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
-import javax.servlet.ServletException;
-
+import com.openshift.jenkins.plugins.pipeline.model.IOpenShiftPlugin;
+import com.openshift.jenkins.plugins.pipeline.model.IOpenShiftPluginDescriptorValidation;
+import com.openshift.restclient.IClient;
+import com.openshift.restclient.ResourceKind;
+import com.openshift.restclient.model.IImageStream;
 import hudson.EnvVars;
+import hudson.Extension;
+import hudson.FilePath;
+import hudson.Launcher;
+import hudson.model.AbstractProject;
 import hudson.model.Job;
+import hudson.model.Run;
+import hudson.model.TaskListener;
+import hudson.scm.*;
+import hudson.scm.PollingResult.Change;
+import hudson.util.FormValidation;
 import jenkins.model.Jenkins;
 import net.sf.json.JSONObject;
-
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.StaplerRequest;
 
-import com.openshift.jenkins.plugins.pipeline.model.IOpenShiftPlugin;
-import com.openshift.restclient.IClient;
-import com.openshift.restclient.ResourceKind;
-//import com.openshift.restclient.authorization.TokenAuthorizationStrategy;
-import com.openshift.restclient.model.IImageStream;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.servlet.ServletException;
+import java.io.File;
+import java.io.IOException;
+import java.util.Map;
 
-import hudson.Extension;
-import hudson.FilePath;
-import hudson.Launcher;
-import hudson.model.TaskListener;
-import hudson.model.AbstractProject;
-import hudson.model.Run;
-import hudson.scm.ChangeLogParser;
-import hudson.scm.PollingResult;
-import hudson.scm.PollingResult.Change;
-import hudson.scm.SCMDescriptor;
-import hudson.scm.SCMRevisionState;
-import hudson.scm.SCM;
-import hudson.util.FormValidation;
+//import com.openshift.restclient.authorization.TokenAuthorizationStrategy;
 
 public class OpenShiftImageStreams extends SCM implements IOpenShiftPlugin {
 	
@@ -232,26 +226,14 @@ public class OpenShiftImageStreams extends SCM implements IOpenShiftPlugin {
 
 
 	@Extension
-    public static class DescriptorImpl extends SCMDescriptor {
+    public static class DescriptorImpl extends SCMDescriptor implements IOpenShiftPluginDescriptorValidation {
 
         public DescriptorImpl() {
             super(OpenShiftImageStreams.class, null);
             load();
         }
 
-        public FormValidation doCheckApiURL(@QueryParameter String value)
-                throws IOException, ServletException {
-        	// with some of the paths into the Image Stream SCM, the env vars typically available for the build steps are not available,
-        	// but for now, we fall back on "https://openshift.default.svc.cluster.local" if they do not specify
-            return ParamVerify.doCheckApiURL(value);
-        }
 
-        public FormValidation doCheckNamespace(@QueryParameter String value)
-                throws IOException, ServletException {
-			// If a namespace is not specified, the default one is going to be used
-        	return ParamVerify.doCheckNamespace(value);
-        }
-        
         public FormValidation doCheckTag(@QueryParameter String value)
                 throws IOException, ServletException {
             return ParamVerify.doCheckTag(value);
@@ -262,11 +244,6 @@ public class OpenShiftImageStreams extends SCM implements IOpenShiftPlugin {
             return ParamVerify.doCheckImageStreamName(value);
         }
         
-        public FormValidation doCheckAuthToken(@QueryParameter String value)
-                throws IOException, ServletException {
-        	return ParamVerify.doCheckToken(value);
-        }
-
 		@Override
 		public String getDisplayName() {
 			return DISPLAY_NAME;
@@ -291,11 +268,6 @@ public class OpenShiftImageStreams extends SCM implements IOpenShiftPlugin {
 		this.auth = auth;
 	}
 
-/*	@Override
-	public void setToken(TokenAuthorizationStrategy token) {
-		this.bearerToken = token;
-	}
-*/
 	@Override
 	public boolean coreLogic(Launcher launcher, TaskListener listener, Map<String,String> overrides) {
 		return false;
@@ -305,12 +277,5 @@ public class OpenShiftImageStreams extends SCM implements IOpenShiftPlugin {
 	public Auth getAuth() {
 		return auth;
 	}
-
-/*	@Override
-	public TokenAuthorizationStrategy getToken() {
-		return bearerToken;
-	}
-*/
-
 
 }

--- a/src/main/java/com/openshift/jenkins/plugins/pipeline/OpenShiftImageTagger.java
+++ b/src/main/java/com/openshift/jenkins/plugins/pipeline/OpenShiftImageTagger.java
@@ -1,6 +1,7 @@
 package com.openshift.jenkins.plugins.pipeline;
 
 import com.openshift.jenkins.plugins.pipeline.model.IOpenShiftImageTagger;
+import com.openshift.jenkins.plugins.pipeline.model.IOpenShiftPluginDescriptorValidation;
 import hudson.Extension;
 import hudson.model.AbstractProject;
 import hudson.tasks.BuildStepDescriptor;
@@ -105,7 +106,7 @@ public class OpenShiftImageTagger extends OpenShiftBaseStep implements IOpenShif
      *
      */
     @Extension // This indicates to Jenkins that this is an implementation of an extension point.
-    public static final class DescriptorImpl extends BuildStepDescriptor<Builder> {
+    public static final class DescriptorImpl extends BuildStepDescriptor<Builder> implements IOpenShiftPluginDescriptorValidation {
         /**
          * To persist global configuration information,
          * simply store it in a field and call save().
@@ -122,28 +123,7 @@ public class OpenShiftImageTagger extends OpenShiftBaseStep implements IOpenShif
             load();
         }
 
-        /**
-         * Performs on-the-fly validation of the various fields.
-         *
-         * @param value
-         *      This parameter receives the value that the user has typed.
-         * @return
-         *      Indicates the outcome of the validation. This is sent to the browser.
-         *      <p>
-         *      Note that returning {@link FormValidation#error(String)} does not
-         *      prevent the form from being saved. It just means that a message
-         *      will be displayed to the user. 
-         */
-        public FormValidation doCheckApiURL(@QueryParameter String value)
-                throws IOException, ServletException {
-            return ParamVerify.doCheckApiURL(value);
-        }
 
-        public FormValidation doCheckNamespace(@QueryParameter String value)
-                throws IOException, ServletException {
-            return ParamVerify.doCheckNamespace(value);
-        }
-        
         public FormValidation doCheckDestinationNamespace(@QueryParameter String value)
                 throws IOException, ServletException {
         	// change reuse doCheckNamespace for destination namespace
@@ -160,7 +140,6 @@ public class OpenShiftImageTagger extends OpenShiftBaseStep implements IOpenShif
             return ParamVerify.doCheckProdTag(value);
         }
 
-
         public FormValidation doCheckTestStream(@QueryParameter String value)
                 throws IOException, ServletException {
             return ParamVerify.doCheckTestStream(value);
@@ -171,16 +150,10 @@ public class OpenShiftImageTagger extends OpenShiftBaseStep implements IOpenShif
             return ParamVerify.doCheckProdStream(value);
         }
 
-        public FormValidation doCheckAuthToken(@QueryParameter String value)
-                throws IOException, ServletException {
-        	return ParamVerify.doCheckToken(value);
-        }
-        
         public FormValidation doCheckDestinationAuthToken(@QueryParameter String value)
                 throws IOException, ServletException {
         	return ParamVerify.doCheckDestTagToken(value);
         }
-
 
         public boolean isApplicable(Class<? extends AbstractProject> aClass) {
             // Indicates that this builder can be used with all kinds of project types 

--- a/src/main/java/com/openshift/jenkins/plugins/pipeline/OpenShiftScaler.java
+++ b/src/main/java/com/openshift/jenkins/plugins/pipeline/OpenShiftScaler.java
@@ -1,35 +1,31 @@
 package com.openshift.jenkins.plugins.pipeline;
-import hudson.Extension;
-import hudson.util.FormValidation;
-import hudson.model.AbstractProject;
-import hudson.tasks.Builder;
-import hudson.tasks.BuildStepDescriptor;
-import net.sf.json.JSONObject;
-
-import org.kohsuke.stapler.DataBoundConstructor;
-import org.kohsuke.stapler.StaplerRequest;
-import org.kohsuke.stapler.QueryParameter;
 
 import com.openshift.jenkins.plugins.pipeline.model.GlobalConfig;
+import com.openshift.jenkins.plugins.pipeline.model.IOpenShiftPluginDescriptorValidation;
 import com.openshift.jenkins.plugins.pipeline.model.IOpenShiftScaler;
+import hudson.Extension;
+import hudson.model.AbstractProject;
+import hudson.tasks.BuildStepDescriptor;
+import hudson.tasks.Builder;
+import hudson.util.FormValidation;
+import net.sf.json.JSONObject;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.QueryParameter;
+import org.kohsuke.stapler.StaplerRequest;
 
 import javax.servlet.ServletException;
-
 import java.io.IOException;
-import java.util.Map;
 
-public class OpenShiftScaler extends OpenShiftBaseStep implements IOpenShiftScaler {
+public class OpenShiftScaler extends TimedOpenShiftBaseStep implements IOpenShiftScaler {
 
-	
     protected final String depCfg;
     protected final String replicaCount;
     protected final String verifyReplicaCount;
-    protected String waitTime;
-    
+
     // Fields in config.jelly must match the parameter names in the "DataBoundConstructor"
     @DataBoundConstructor
-    public OpenShiftScaler(String apiURL, String depCfg, String namespace, String replicaCount, String authToken, String verbose, String verifyReplicaCount) {
-    	super(apiURL, namespace, authToken, verbose);
+    public OpenShiftScaler(String apiURL, String depCfg, String namespace, String replicaCount, String authToken, String verbose, String verifyReplicaCount, String waitTime ) {
+    	super(apiURL, namespace, authToken, verbose, waitTime);
         this.depCfg = depCfg;
         this.replicaCount = replicaCount;
         this.verifyReplicaCount = verifyReplicaCount;
@@ -52,18 +48,6 @@ public class OpenShiftScaler extends OpenShiftBaseStep implements IOpenShiftScal
 		return verifyReplicaCount;
 	}
 	
-	public String getWaitTime() {
-		return waitTime;
-	}
-	
-	public String getWaitTime(Map<String, String> overrides) {
-		String val = getOverride(getWaitTime(), overrides);
-		if (val.length() > 0)
-			return val;
-		return Long.toString(getDescriptor().getWait());
-	}
-	
-    
     // Overridden for better type safety.
     // If your plugin doesn't really define any property on Descriptor,
     // you don't have to do this.
@@ -78,8 +62,7 @@ public class OpenShiftScaler extends OpenShiftBaseStep implements IOpenShiftScal
      *
      */
     @Extension // This indicates to Jenkins that this is an implementation of an extension point.
-    public static final class DescriptorImpl extends BuildStepDescriptor<Builder> {
-    	private long wait = GlobalConfig.SCALER_WAIT;
+    public static final class DescriptorImpl extends BuildStepDescriptor<Builder> implements IOpenShiftPluginDescriptorValidation {
         /**
          * To persist global configuration information,
          * simply store it in a field and call save().
@@ -96,42 +79,15 @@ public class OpenShiftScaler extends OpenShiftBaseStep implements IOpenShiftScal
             load();
         }
 
-        /**
-         * Performs on-the-fly validation of the various fields.
-         *
-         * @param value
-         *      This parameter receives the value that the user has typed.
-         * @return
-         *      Indicates the outcome of the validation. This is sent to the browser.
-         *      <p>
-         *      Note that returning {@link FormValidation#error(String)} does not
-         *      prevent the form from being saved. It just means that a message
-         *      will be displayed to the user. 
-         */
-        public FormValidation doCheckApiURL(@QueryParameter String value)
-                throws IOException, ServletException {
-        	return ParamVerify.doCheckApiURL(value);
-        }
 
         public FormValidation doCheckDepCfg(@QueryParameter String value)
                 throws IOException, ServletException {
         	return ParamVerify.doCheckDepCfg(value);
         }
 
-        public FormValidation doCheckNamespace(@QueryParameter String value)
-                throws IOException, ServletException {
-        	return ParamVerify.doCheckNamespace(value);
-        }
-        
-        
         public FormValidation doCheckReplicaCount(@QueryParameter String value)
                 throws IOException, ServletException {
         	return ParamVerify.doCheckReplicaCountRequired(value);
-        }
-
-        public FormValidation doCheckAuthToken(@QueryParameter String value)
-                throws IOException, ServletException {
-        	return ParamVerify.doCheckToken(value);
         }
 
         public boolean isApplicable(Class<? extends AbstractProject> aClass) {
@@ -146,16 +102,11 @@ public class OpenShiftScaler extends OpenShiftBaseStep implements IOpenShiftScal
             return DISPLAY_NAME;
         }
         
-        public long getWait() {
-        	return wait;
-        }
-
         @Override
         public boolean configure(StaplerRequest req, JSONObject formData) throws FormException {
             // To persist global configuration information,
             // pull info from formData, set appropriate instance field (which should have a getter), and call save().
-        	wait = formData.getLong("wait");
-        	GlobalConfig.setScalerWait(wait);
+        	GlobalConfig.setScalerWait(formData.getLong("wait"));
             save();
             return super.configure(req,formData);
         }

--- a/src/main/java/com/openshift/jenkins/plugins/pipeline/OpenShiftScalerPostAction.java
+++ b/src/main/java/com/openshift/jenkins/plugins/pipeline/OpenShiftScalerPostAction.java
@@ -1,35 +1,31 @@
 package com.openshift.jenkins.plugins.pipeline;
+
+import com.openshift.jenkins.plugins.pipeline.model.IOpenShiftPluginDescriptorValidation;
+import com.openshift.jenkins.plugins.pipeline.model.IOpenShiftScaler;
 import hudson.Extension;
-import hudson.util.FormValidation;
 import hudson.model.AbstractProject;
 import hudson.tasks.BuildStepDescriptor;
 import hudson.tasks.Publisher;
+import hudson.util.FormValidation;
 import net.sf.json.JSONObject;
-
 import org.kohsuke.stapler.DataBoundConstructor;
-import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.QueryParameter;
-
-import com.openshift.jenkins.plugins.pipeline.model.GlobalConfig;
-import com.openshift.jenkins.plugins.pipeline.model.IOpenShiftScaler;
+import org.kohsuke.stapler.StaplerRequest;
 
 import javax.servlet.ServletException;
-
 import java.io.IOException;
-import java.util.Map;
 
-public class OpenShiftScalerPostAction extends OpenShiftBasePostAction implements IOpenShiftScaler {
+public class OpenShiftScalerPostAction extends TimedOpenShiftBasePostAction implements IOpenShiftScaler {
 
 	
     protected final String depCfg;
     protected final String replicaCount;
     protected final String verifyReplicaCount;
-    protected String waitTime;
-    
+
     // Fields in config.jelly must match the parameter names in the "DataBoundConstructor"
     @DataBoundConstructor
-    public OpenShiftScalerPostAction(String apiURL, String depCfg, String namespace, String replicaCount, String authToken, String verbose, String verifyReplicaCount) {
-    	super(apiURL, namespace, authToken, verbose);
+    public OpenShiftScalerPostAction(String apiURL, String depCfg, String namespace, String replicaCount, String authToken, String verbose, String verifyReplicaCount, String waitTime) {
+    	super(apiURL, namespace, authToken, verbose, waitTime);
         this.depCfg = depCfg;
         this.replicaCount = replicaCount;
         this.verifyReplicaCount = verifyReplicaCount;
@@ -52,18 +48,6 @@ public class OpenShiftScalerPostAction extends OpenShiftBasePostAction implement
 		return verifyReplicaCount;
 	}
 	
-	public String getWaitTime() {
-		return waitTime;
-	}
-	
-	public String getWaitTime(Map<String, String> overrides) {
-		String val = getOverride(getWaitTime(), overrides);
-		if (val.length() > 0)
-			return val;
-		return Long.toString(getDescriptor().getWait());
-	}
-	
-    
     // Overridden for better type safety.
     // If your plugin doesn't really define any property on Descriptor,
     // you don't have to do this.
@@ -78,8 +62,7 @@ public class OpenShiftScalerPostAction extends OpenShiftBasePostAction implement
      *
      */
     @Extension // This indicates to Jenkins that this is an implementation of an extension point.
-    public static final class DescriptorImpl extends BuildStepDescriptor<Publisher> {
-    	private long wait = GlobalConfig.SCALER_WAIT;
+    public static final class DescriptorImpl extends BuildStepDescriptor<Publisher> implements IOpenShiftPluginDescriptorValidation {
         /**
          * To persist global configuration information,
          * simply store it in a field and call save().
@@ -96,42 +79,14 @@ public class OpenShiftScalerPostAction extends OpenShiftBasePostAction implement
             load();
         }
 
-        /**
-         * Performs on-the-fly validation of the various fields.
-         *
-         * @param value
-         *      This parameter receives the value that the user has typed.
-         * @return
-         *      Indicates the outcome of the validation. This is sent to the browser.
-         *      <p>
-         *      Note that returning {@link FormValidation#error(String)} does not
-         *      prevent the form from being saved. It just means that a message
-         *      will be displayed to the user. 
-         */
-        public FormValidation doCheckApiURL(@QueryParameter String value)
-                throws IOException, ServletException {
-        	return ParamVerify.doCheckApiURL(value);
-        }
-
         public FormValidation doCheckDepCfg(@QueryParameter String value)
                 throws IOException, ServletException {
         	return ParamVerify.doCheckDepCfg(value);
         }
 
-        public FormValidation doCheckNamespace(@QueryParameter String value)
-                throws IOException, ServletException {
-        	return ParamVerify.doCheckNamespace(value);
-        }
-        
-        
         public FormValidation doCheckReplicaCount(@QueryParameter String value)
                 throws IOException, ServletException {
         	return ParamVerify.doCheckReplicaCountRequired(value);
-        }
-
-        public FormValidation doCheckAuthToken(@QueryParameter String value)
-                throws IOException, ServletException {
-        	return ParamVerify.doCheckToken(value);
         }
 
         public boolean isApplicable(Class<? extends AbstractProject> aClass) {
@@ -146,15 +101,10 @@ public class OpenShiftScalerPostAction extends OpenShiftBasePostAction implement
             return DISPLAY_NAME;
         }
         
-        public long getWait() {
-        	return wait;
-        }
-
         @Override
         public boolean configure(StaplerRequest req, JSONObject formData) throws FormException {
             // To persist global configuration information,
             // pull info from formData, set appropriate instance field (which should have a getter), and call save().
-        	wait = formData.getLong("wait");
             save();
             return super.configure(req,formData);
         }

--- a/src/main/java/com/openshift/jenkins/plugins/pipeline/OpenShiftServiceVerifier.java
+++ b/src/main/java/com/openshift/jenkins/plugins/pipeline/OpenShiftServiceVerifier.java
@@ -1,20 +1,19 @@
 package com.openshift.jenkins.plugins.pipeline;
-import hudson.Extension;
-import hudson.util.FormValidation;
-import hudson.model.AbstractProject;
-import hudson.tasks.Builder;
-import hudson.tasks.BuildStepDescriptor;
-import net.sf.json.JSONObject;
-
-import org.kohsuke.stapler.DataBoundConstructor;
-import org.kohsuke.stapler.StaplerRequest;
-import org.kohsuke.stapler.QueryParameter;
 
 import com.openshift.jenkins.plugins.pipeline.model.GlobalConfig;
+import com.openshift.jenkins.plugins.pipeline.model.IOpenShiftPluginDescriptorValidation;
 import com.openshift.jenkins.plugins.pipeline.model.IOpenShiftServiceVerifier;
+import hudson.Extension;
+import hudson.model.AbstractProject;
+import hudson.tasks.BuildStepDescriptor;
+import hudson.tasks.Builder;
+import hudson.util.FormValidation;
+import net.sf.json.JSONObject;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.QueryParameter;
+import org.kohsuke.stapler.StaplerRequest;
 
 import javax.servlet.ServletException;
-
 import java.io.IOException;
 import java.util.Map;
 
@@ -65,8 +64,8 @@ public class OpenShiftServiceVerifier extends OpenShiftBaseStep implements IOpen
      *
      */
     @Extension // This indicates to Jenkins that this is an implementation of an extension point.
-    public static final class DescriptorImpl extends BuildStepDescriptor<Builder> {
-    	private int retry = GlobalConfig.SERVICE_VERIFY_RETRY;
+    public static final class DescriptorImpl extends BuildStepDescriptor<Builder> implements IOpenShiftPluginDescriptorValidation {
+    	private int retry = GlobalConfig.DEFAULT_SERVICE_VERIFY_RETRY;
         /**
          * To persist global configuration information,
          * simply store it in a field and call save().
@@ -83,36 +82,9 @@ public class OpenShiftServiceVerifier extends OpenShiftBaseStep implements IOpen
             load();
         }
 
-        /**
-         * Performs on-the-fly validation of the various fields.
-         *
-         * @param value
-         *      This parameter receives the value that the user has typed.
-         * @return
-         *      Indicates the outcome of the validation. This is sent to the browser.
-         *      <p>
-         *      Note that returning {@link FormValidation#error(String)} does not
-         *      prevent the form from being saved. It just means that a message
-         *      will be displayed to the user. 
-         */
-        public FormValidation doCheckApiURL(@QueryParameter String value)
-                throws IOException, ServletException {
-            return ParamVerify.doCheckApiURL(value);
-        }
-
         public FormValidation doCheckSvcName(@QueryParameter String value)
                 throws IOException, ServletException {
             return ParamVerify.doCheckSvcName(value);
-        }
-
-        public FormValidation doCheckNamespace(@QueryParameter String value)
-                throws IOException, ServletException {
-            return ParamVerify.doCheckNamespace(value);
-        }
-
-        public FormValidation doCheckAuthToken(@QueryParameter String value)
-                throws IOException, ServletException {
-        	return ParamVerify.doCheckToken(value);
         }
 
         public boolean isApplicable(Class<? extends AbstractProject> aClass) {

--- a/src/main/java/com/openshift/jenkins/plugins/pipeline/ParamVerify.java
+++ b/src/main/java/com/openshift/jenkins/plugins/pipeline/ParamVerify.java
@@ -37,35 +37,30 @@ public class ParamVerify {
         }
 	}
 
-    public static FormValidation doCheckApiURL(@QueryParameter String value)
-            throws IOException, ServletException {
+    public static FormValidation doCheckApiURL(@QueryParameter String value) {
         if (value.length() == 0)
             return FormValidation.warning("Unless you specify a value here, one of the default API endpoints will be used; see this field's help or https://github.com/openshift/jenkins-plugin#common-aspects-across-the-rest-based-functions-build-steps-scm-post-build-actions for details");
         return FormValidation.ok();
     }
 
-    public static FormValidation doCheckBldCfg(@QueryParameter String value)
-            throws IOException, ServletException {
+    public static FormValidation doCheckBldCfg(@QueryParameter String value) {
         if (value.length() == 0)
             return FormValidation.error("You must set a BuildConfig name");
         return FormValidation.ok();
     }
     
-    public static FormValidation doCheckNamespace(@QueryParameter String value)
-            throws IOException, ServletException {
+    public static FormValidation doCheckNamespace(@QueryParameter String value) {
         if (value.length() == 0)
             return FormValidation.warning("Unless you specify a value here, the default namespace will be used; see this field's help or https://github.com/openshift/jenkins-plugin#common-aspects-across-the-rest-based-functions-build-steps-scm-post-build-actions for details");
         return FormValidation.ok();
     }
     
-    public static FormValidation doCheckToken(@QueryParameter String value)
-    		throws IOException, ServletException {
+    public static FormValidation doCheckToken(String value) {
     	if (value.length() == 0)
     		return FormValidation.warning("Unless you specify a value here, the default token will be used; see this field's help or https://github.com/openshift/jenkins-plugin#common-aspects-across-the-rest-based-functions-build-steps-scm-post-build-actions for details");
     	return FormValidation.ok();
     }
-        
-    
+
     public static FormValidation doCheckDestTagToken(@QueryParameter String value)
     		throws IOException, ServletException {
     	if (value.length() == 0)
@@ -73,26 +68,14 @@ public class ParamVerify {
     	return FormValidation.ok();
     }
     
-    public static FormValidation doCheckCheckForTriggeredDeployments(@QueryParameter String value)
-            throws IOException, ServletException {
-        if (value.length() == 0)
-            return FormValidation.error("Please set trigger check");
-        try {
-        	Boolean.parseBoolean(value);
-        } catch (Throwable t) {
-        	return FormValidation.error(t.getMessage());
-        }
-        return FormValidation.ok();
-    }
-
-    public static FormValidation doCheckCheckForWaitTime(@QueryParameter String value)
-            throws IOException, ServletException {
-        if (value.length() == 0)
+    public static FormValidation doCheckForWaitTime(String value) {
+        value = (value==null)?"":value.trim();
+        if ( value.isEmpty() ) // timeout will fallthrough to default
             return FormValidation.ok();
         try {
         	Long.parseLong(value);
         } catch (Throwable t) {
-        	return FormValidation.error(t.getMessage());
+            return FormValidation.ok( "Non-numeric value specified. During execution, an attempt will be made to resolve [%s] as a build parameter or Jenkins global variable.", value );
         }
         return FormValidation.ok();
     }
@@ -123,85 +106,74 @@ public class ParamVerify {
         return FormValidation.ok();
     }
     
-    public static FormValidation doCheckReplicaCount(@QueryParameter String value)
-            throws IOException, ServletException {
+    public static FormValidation doCheckReplicaCount(@QueryParameter String value) {
         try {
         	Integer.decode(value);
         } catch (NumberFormatException e) {
-        	return FormValidation.warning("If you want to validate the number of replicas, please specify an integer for the replica count");
+            return FormValidation.ok( "Non-numeric value specified. During execution, an attempt will be made to resolve [%s] as a build parameter or Jenkins global variable.", value );
         }
         return FormValidation.ok();
     }
 
-    public static FormValidation doCheckReplicaCountRequired(@QueryParameter String value)
-            throws IOException, ServletException {
+    public static FormValidation doCheckReplicaCountRequired(@QueryParameter String value) {
         try {
         	Integer.decode(value);
         } catch (NumberFormatException e) {
-        	return FormValidation.error("You must specify an integer for the replica count");
+            return FormValidation.ok( "Non-numeric value specified. During execution, an attempt will be made to resolve [%s] as a build parameter or Jenkins global variable.", value );
         }
         return FormValidation.ok();
     }
 
-    public static FormValidation doCheckTestTag(@QueryParameter String value)
-            throws IOException, ServletException {
+    public static FormValidation doCheckTestTag(@QueryParameter String value) {
         if (value.length() == 0)
             return FormValidation.error("Please set the name of image stream tag that serves as the source of the operation");
         return FormValidation.ok();
     }
 
-    public static FormValidation doCheckProdTag(@QueryParameter String value)
-            throws IOException, ServletException {
+    public static FormValidation doCheckProdTag(@QueryParameter String value) {
         if (value.length() == 0)
             return FormValidation.error("Please set the name of the image stream tag that serves as the destination or target of the operation");
         return FormValidation.ok();
     }
 
 
-    public static FormValidation doCheckTestStream(@QueryParameter String value)
-            throws IOException, ServletException {
+    public static FormValidation doCheckTestStream(@QueryParameter String value) {
         if (value.length() == 0)
             return FormValidation.error("Please set the name of image stream that serves as the source of the operation");
         return FormValidation.ok();
     }
 
-    public static FormValidation doCheckProdStream(@QueryParameter String value)
-            throws IOException, ServletException {
+    public static FormValidation doCheckProdStream(@QueryParameter String value) {
         if (value.length() == 0)
             return FormValidation.error("Please set the name of the image stream that serves as the destination or target of the operation");
         return FormValidation.ok();
     }
 
-    public static FormValidation doCheckSvcName(@QueryParameter String value)
-            throws IOException, ServletException {
+    public static FormValidation doCheckSvcName(@QueryParameter String value) {
         if (value.length() == 0)
             return FormValidation.error("Please set the name of the Service to validate");
         return FormValidation.ok();
     }
 
-    public static FormValidation doCheckTag(@QueryParameter String value)
-            throws IOException, ServletException {
+    public static FormValidation doCheckTag(@QueryParameter String value) {
         if (value.length() == 0)
             return FormValidation.error("Please set the name of the image stream tag you want to poll");
         return FormValidation.ok();
     }
     
-    public static FormValidation doCheckImageStreamName(@QueryParameter String value)
-            throws IOException, ServletException {
+    public static FormValidation doCheckImageStreamName(@QueryParameter String value) {
         if (value.length() == 0)
             return FormValidation.error("Please set the name of the image stream you want to poll");
         return FormValidation.ok();
     }
     
-    public static FormValidation doCheckType(@QueryParameter String value) 
-    		throws IOException, ServletException {
+    public static FormValidation doCheckType(@QueryParameter String value) {
     	if (value.length() == 0)
     		return FormValidation.error("Please set the name of the API object type you want to delete");
     	return FormValidation.ok();
     }
     
-    public static FormValidation doCheckKey(@QueryParameter String value) 
-    		throws IOException, ServletException {
+    public static FormValidation doCheckKey(@QueryParameter String value) {
     	if (value.length() == 0)
     		return FormValidation.error("Please set the name of the key of the API object you want to delete");
     	return FormValidation.ok();

--- a/src/main/java/com/openshift/jenkins/plugins/pipeline/TimedOpenShiftBasePostAction.java
+++ b/src/main/java/com/openshift/jenkins/plugins/pipeline/TimedOpenShiftBasePostAction.java
@@ -1,0 +1,21 @@
+package com.openshift.jenkins.plugins.pipeline;
+
+import com.openshift.jenkins.plugins.pipeline.model.ITimedOpenShiftPlugin;
+import jenkins.tasks.SimpleBuildStep;
+
+import java.io.Serializable;
+
+public abstract class TimedOpenShiftBasePostAction extends OpenShiftBasePostAction implements SimpleBuildStep, Serializable, ITimedOpenShiftPlugin {
+
+    protected final String waitTime;
+
+    public TimedOpenShiftBasePostAction(String apiURL, String namespace, String authToken, String verbose, String waitTime) {
+		super( apiURL, namespace, authToken, verbose );
+		this.waitTime = waitTime;
+	}
+
+	final public String getWaitTime() {
+		return waitTime;
+	}
+
+}

--- a/src/main/java/com/openshift/jenkins/plugins/pipeline/TimedOpenShiftBaseStep.java
+++ b/src/main/java/com/openshift/jenkins/plugins/pipeline/TimedOpenShiftBaseStep.java
@@ -1,0 +1,21 @@
+package com.openshift.jenkins.plugins.pipeline;
+
+import com.openshift.jenkins.plugins.pipeline.model.ITimedOpenShiftPlugin;
+import jenkins.tasks.SimpleBuildStep;
+
+import java.io.Serializable;
+
+public abstract class TimedOpenShiftBaseStep extends OpenShiftBaseStep  implements SimpleBuildStep, Serializable, ITimedOpenShiftPlugin {
+
+    protected final String waitTime;
+
+    protected TimedOpenShiftBaseStep(String apiURL, String namespace, String authToken, String verbose, String waitTime) {
+		super( apiURL, namespace, authToken, verbose );
+		this.waitTime = waitTime;
+    }
+
+    final public String getWaitTime() {
+		return waitTime;
+	}
+
+}

--- a/src/main/java/com/openshift/jenkins/plugins/pipeline/dsl/OpenShiftBuildVerifier.java
+++ b/src/main/java/com/openshift/jenkins/plugins/pipeline/dsl/OpenShiftBuildVerifier.java
@@ -1,31 +1,26 @@
 package com.openshift.jenkins.plugins.pipeline.dsl;
 
+import com.openshift.jenkins.plugins.pipeline.ParamVerify;
+import com.openshift.jenkins.plugins.pipeline.model.IOpenShiftBuildVerifier;
 import hudson.Extension;
-import hudson.model.Action;
-import hudson.model.BuildListener;
 import hudson.model.AbstractBuild;
 import hudson.model.AbstractProject;
+import hudson.model.Action;
+import hudson.model.BuildListener;
 import hudson.tasks.BuildStepMonitor;
-
-import java.util.Collection;
-import java.util.Map;
-import java.util.logging.Logger;
-
 import org.jenkinsci.plugins.workflow.steps.AbstractStepDescriptorImpl;
 import org.jenkinsci.plugins.workflow.steps.Step;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 
-import com.openshift.jenkins.plugins.pipeline.ParamVerify;
-import com.openshift.jenkins.plugins.pipeline.model.GlobalConfig;
-import com.openshift.jenkins.plugins.pipeline.model.IOpenShiftBuildVerifier;
+import java.util.Collection;
+import java.util.Map;
 
-public class OpenShiftBuildVerifier extends OpenShiftBaseStep implements IOpenShiftBuildVerifier {
+public class OpenShiftBuildVerifier extends TimedOpenShiftBaseStep implements IOpenShiftBuildVerifier {
 
     protected final String bldCfg;
     protected String checkForTriggeredDeployments;
-    protected String waitTime;
-    
+
     @DataBoundConstructor public OpenShiftBuildVerifier(String bldCfg) {
     	this.bldCfg = bldCfg;
 	}
@@ -64,27 +59,6 @@ public class OpenShiftBuildVerifier extends OpenShiftBaseStep implements IOpenSh
 	@DataBoundSetter public void setCheckForTriggeredDeployments(String checkForTriggeredDeployments) {
 		this.checkForTriggeredDeployments = checkForTriggeredDeployments;
 	}
-	
-	@Override
-	public String getWaitTime() {
-		return waitTime;
-	}
-
-	@Override
-	public String getWaitTime(Map<String, String> overrides) {
-		String val = getOverride(getWaitTime(), overrides);
-		if (val.length() > 0)
-			return val;
-		return Long.toString(GlobalConfig.getBuildVerifyWait());
-	}
-
-	@DataBoundSetter public void setWaitTime(String waitTime) {
-		this.waitTime = waitTime;
-	}
-	
-
-    private static final Logger LOGGER = Logger.getLogger(OpenShiftBuilder.class.getName());
-
 
 	@Extension
     public static class DescriptorImpl extends AbstractStepDescriptorImpl {

--- a/src/main/java/com/openshift/jenkins/plugins/pipeline/dsl/OpenShiftBuilder.java
+++ b/src/main/java/com/openshift/jenkins/plugins/pipeline/dsl/OpenShiftBuilder.java
@@ -1,36 +1,32 @@
 package com.openshift.jenkins.plugins.pipeline.dsl;
 import com.openshift.jenkins.plugins.pipeline.NameValuePair;
+import com.openshift.jenkins.plugins.pipeline.ParamVerify;
+import com.openshift.jenkins.plugins.pipeline.model.IOpenShiftBuilder;
 import hudson.Extension;
-import hudson.model.Action;
-import hudson.model.BuildListener;
 import hudson.model.AbstractBuild;
 import hudson.model.AbstractProject;
+import hudson.model.Action;
+import hudson.model.BuildListener;
 import hudson.tasks.BuildStepMonitor;
-
 import org.jenkinsci.plugins.workflow.steps.AbstractStepDescriptorImpl;
 import org.jenkinsci.plugins.workflow.steps.Step;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 
-import com.openshift.jenkins.plugins.pipeline.ParamVerify;
-import com.openshift.jenkins.plugins.pipeline.model.GlobalConfig;
-import com.openshift.jenkins.plugins.pipeline.model.IOpenShiftBuilder;
-
-import java.io.FileOutputStream;
 import java.io.IOException;
-import java.util.*;
-import java.util.logging.Level;
-import java.util.logging.Logger;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
 
 
-public class OpenShiftBuilder extends OpenShiftBaseStep implements IOpenShiftBuilder {
+public class OpenShiftBuilder extends TimedOpenShiftBaseStep implements IOpenShiftBuilder {
 	
     protected final String bldCfg;
     protected String commitID;
     protected String buildName;
     protected String showBuildLogs;
     protected String checkForTriggeredDeployments;
-    protected String waitTime;
     protected List<NameValuePair> envVars = new ArrayList<>();
 
     // Fields in config.jelly must match the parameter names in the "DataBoundConstructor"
@@ -88,25 +84,6 @@ public class OpenShiftBuilder extends OpenShiftBaseStep implements IOpenShiftBui
 		this.checkForTriggeredDeployments = checkForTriggeredDeployments;
 	}
 	
-	public String getWaitTime() {
-		return waitTime;
-	}
-	
-	@DataBoundSetter public void setWaitTime(String waitTime) {
-		this.waitTime = waitTime;
-	}
-	
-	public String getWaitTime(Map<String,String> overrides) {
-		String val = getOverride(getWaitTime(), overrides);
-		if (val.length() > 0)
-			return val;
-		return Long.toString(GlobalConfig.getBuildWait());
-	}
-	
-	
-    private static final Logger LOGGER = Logger.getLogger(OpenShiftBuilder.class.getName());
-
-
 	@Extension
     public static class DescriptorImpl extends AbstractStepDescriptorImpl {
 

--- a/src/main/java/com/openshift/jenkins/plugins/pipeline/dsl/OpenShiftDeployer.java
+++ b/src/main/java/com/openshift/jenkins/plugins/pipeline/dsl/OpenShiftDeployer.java
@@ -1,30 +1,26 @@
 package com.openshift.jenkins.plugins.pipeline.dsl;
 
+import com.openshift.jenkins.plugins.pipeline.ParamVerify;
+import com.openshift.jenkins.plugins.pipeline.model.IOpenShiftDeployer;
 import hudson.Extension;
-import hudson.model.Action;
-import hudson.model.BuildListener;
 import hudson.model.AbstractBuild;
 import hudson.model.AbstractProject;
+import hudson.model.Action;
+import hudson.model.BuildListener;
 import hudson.tasks.BuildStepMonitor;
-
-import java.util.Collection;
-import java.util.Map;
-import java.util.logging.Logger;
-
 import org.jenkinsci.plugins.workflow.steps.AbstractStepDescriptorImpl;
 import org.jenkinsci.plugins.workflow.steps.Step;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 
-import com.openshift.jenkins.plugins.pipeline.ParamVerify;
-import com.openshift.jenkins.plugins.pipeline.model.GlobalConfig;
-import com.openshift.jenkins.plugins.pipeline.model.IOpenShiftDeployer;
+import java.util.Collection;
+import java.util.Map;
+import java.util.logging.Logger;
 
-public class OpenShiftDeployer extends OpenShiftBaseStep implements IOpenShiftDeployer {
+public class OpenShiftDeployer extends TimedOpenShiftBaseStep implements IOpenShiftDeployer {
 	
 	protected final String depCfg;
-	protected String waitTime;
-    
+
     @DataBoundConstructor public OpenShiftDeployer(String depCfg) {
     	this.depCfg = depCfg;
 	}   
@@ -33,21 +29,6 @@ public class OpenShiftDeployer extends OpenShiftBaseStep implements IOpenShiftDe
 		return depCfg;
 	}
 
-	public String getWaitTime() {
-		return waitTime;
-	}
-	
-	public String getWaitTime(Map<String, String> overrides) {
-		String val = getOverride(getWaitTime(), overrides);
-		if (val.length() > 0)
-			return val;
-		return Long.toString(GlobalConfig.getDeployWait());
-	}
-	
-	@DataBoundSetter public void setWaitTime(String waitTime) {
-		this.waitTime = waitTime;
-	}
-	
 	@Override
 	public boolean prebuild(AbstractBuild<?, ?> build, BuildListener listener) {
 		return true;

--- a/src/main/java/com/openshift/jenkins/plugins/pipeline/dsl/OpenShiftDeploymentVerifier.java
+++ b/src/main/java/com/openshift/jenkins/plugins/pipeline/dsl/OpenShiftDeploymentVerifier.java
@@ -1,32 +1,28 @@
 package com.openshift.jenkins.plugins.pipeline.dsl;
 
+import com.openshift.jenkins.plugins.pipeline.ParamVerify;
+import com.openshift.jenkins.plugins.pipeline.model.IOpenShiftDeploymentVerification;
 import hudson.Extension;
-import hudson.model.Action;
-import hudson.model.BuildListener;
 import hudson.model.AbstractBuild;
 import hudson.model.AbstractProject;
+import hudson.model.Action;
+import hudson.model.BuildListener;
 import hudson.tasks.BuildStepMonitor;
-
-import java.util.Collection;
-import java.util.Map;
-import java.util.logging.Logger;
-
 import org.jenkinsci.plugins.workflow.steps.AbstractStepDescriptorImpl;
 import org.jenkinsci.plugins.workflow.steps.Step;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 
-import com.openshift.jenkins.plugins.pipeline.ParamVerify;
-import com.openshift.jenkins.plugins.pipeline.model.GlobalConfig;
-import com.openshift.jenkins.plugins.pipeline.model.IOpenShiftDeploymentVerification;
+import java.util.Collection;
+import java.util.Map;
+import java.util.logging.Logger;
 
-public class OpenShiftDeploymentVerifier extends OpenShiftBaseStep implements IOpenShiftDeploymentVerification {
+public class OpenShiftDeploymentVerifier extends TimedOpenShiftBaseStep implements IOpenShiftDeploymentVerification {
 	
 	protected final String depCfg;
     protected String replicaCount;
     protected String verifyReplicaCount;
-	protected String waitTime;
-    
+
     @DataBoundConstructor public OpenShiftDeploymentVerifier(String depCfg) {
     	this.depCfg = depCfg;
 	}   
@@ -49,21 +45,6 @@ public class OpenShiftDeploymentVerifier extends OpenShiftBaseStep implements IO
 	
 	@DataBoundSetter public void setVerifyReplicaCount(String verifyReplicaCount) {
 		this.verifyReplicaCount = verifyReplicaCount;
-	}
-	
-	public String getWaitTime() {
-		return waitTime;
-	}
-	
-	public String getWaitTime(Map<String, String> overrides) {
-		String val = getOverride(getWaitTime(), overrides);
-		if (val.length() > 0)
-			return val;
-		return Long.toString(GlobalConfig.getDeployVerifyWait());
-	}
-	
-	@DataBoundSetter public void setWaitTime(String waitTime) {
-		this.waitTime = waitTime;
 	}
 	
 	@Override

--- a/src/main/java/com/openshift/jenkins/plugins/pipeline/dsl/OpenShiftExec.java
+++ b/src/main/java/com/openshift/jenkins/plugins/pipeline/dsl/OpenShiftExec.java
@@ -2,7 +2,6 @@ package com.openshift.jenkins.plugins.pipeline.dsl;
 
 import com.openshift.jenkins.plugins.pipeline.Argument;
 import com.openshift.jenkins.plugins.pipeline.ParamVerify;
-import com.openshift.jenkins.plugins.pipeline.model.GlobalConfig;
 import com.openshift.jenkins.plugins.pipeline.model.IOpenShiftExec;
 import hudson.Extension;
 import hudson.model.AbstractBuild;
@@ -15,19 +14,14 @@ import org.jenkinsci.plugins.workflow.steps.Step;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
-public class OpenShiftExec extends OpenShiftBaseStep implements IOpenShiftExec {
+public class OpenShiftExec extends TimedOpenShiftBaseStep implements IOpenShiftExec {
 
     protected String pod;
     protected String container;
     protected String command;
     protected List<Argument> arguments = new ArrayList<>();
-    protected String waitTime;
 
     @DataBoundConstructor
     public OpenShiftExec( String pod ) {
@@ -49,11 +43,6 @@ public class OpenShiftExec extends OpenShiftBaseStep implements IOpenShiftExec {
         this.arguments = arguments;
     }
 
-    @DataBoundSetter
-    public void setWaitTime(String waitTime) {
-        this.waitTime = waitTime;
-    }
-
     public String getPod() {
         return pod;
     }
@@ -68,17 +57,6 @@ public class OpenShiftExec extends OpenShiftBaseStep implements IOpenShiftExec {
 
     public List<Argument> getArguments() {
         return arguments;
-    }
-
-    public String getWaitTime() {
-        return waitTime;
-    }
-
-    public String getWaitTime(Map<String,String> overrides) {
-        String val = getOverride(getWaitTime(), overrides);
-        if (val.length() > 0)
-            return val;
-        return Long.toString(GlobalConfig.getBuildWait());
     }
 
 	@Extension

--- a/src/main/java/com/openshift/jenkins/plugins/pipeline/dsl/OpenShiftScaler.java
+++ b/src/main/java/com/openshift/jenkins/plugins/pipeline/dsl/OpenShiftScaler.java
@@ -1,32 +1,28 @@
 package com.openshift.jenkins.plugins.pipeline.dsl;
 
+import com.openshift.jenkins.plugins.pipeline.ParamVerify;
+import com.openshift.jenkins.plugins.pipeline.model.IOpenShiftScaler;
 import hudson.Extension;
-import hudson.model.Action;
-import hudson.model.BuildListener;
 import hudson.model.AbstractBuild;
 import hudson.model.AbstractProject;
+import hudson.model.Action;
+import hudson.model.BuildListener;
 import hudson.tasks.BuildStepMonitor;
-
-import java.util.Collection;
-import java.util.Map;
-import java.util.logging.Logger;
-
 import org.jenkinsci.plugins.workflow.steps.AbstractStepDescriptorImpl;
 import org.jenkinsci.plugins.workflow.steps.Step;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 
-import com.openshift.jenkins.plugins.pipeline.ParamVerify;
-import com.openshift.jenkins.plugins.pipeline.model.GlobalConfig;
-import com.openshift.jenkins.plugins.pipeline.model.IOpenShiftScaler;
+import java.util.Collection;
+import java.util.Map;
+import java.util.logging.Logger;
 
-public class OpenShiftScaler extends OpenShiftBaseStep implements IOpenShiftScaler {
+public class OpenShiftScaler extends TimedOpenShiftBaseStep implements IOpenShiftScaler {
 	
 	protected final String depCfg;
     protected final String replicaCount;
     protected String verifyReplicaCount;
-	protected String waitTime;
-    
+
     @DataBoundConstructor public OpenShiftScaler(String depCfg, String replicaCount) {
     	this.depCfg = depCfg;
     	this.replicaCount = replicaCount;
@@ -46,21 +42,6 @@ public class OpenShiftScaler extends OpenShiftBaseStep implements IOpenShiftScal
 	
 	@DataBoundSetter public void setVerifyReplicaCount(String verifyReplicaCount) {
 		this.verifyReplicaCount = verifyReplicaCount;
-	}
-	
-	public String getWaitTime() {
-		return waitTime;
-	}
-	
-	public String getWaitTime(Map<String, String> overrides) {
-		String val = getOverride(getWaitTime(), overrides);
-		if (val.length() > 0)
-			return val;
-		return Long.toString(GlobalConfig.getScalerWait());
-	}
-	
-	@DataBoundSetter public void setWaitTime(String waitTime) {
-		this.waitTime = waitTime;
 	}
 	
 	@Override

--- a/src/main/java/com/openshift/jenkins/plugins/pipeline/dsl/OpenShiftServiceVerifier.java
+++ b/src/main/java/com/openshift/jenkins/plugins/pipeline/dsl/OpenShiftServiceVerifier.java
@@ -1,24 +1,22 @@
 package com.openshift.jenkins.plugins.pipeline.dsl;
 
+import com.openshift.jenkins.plugins.pipeline.ParamVerify;
+import com.openshift.jenkins.plugins.pipeline.model.GlobalConfig;
+import com.openshift.jenkins.plugins.pipeline.model.IOpenShiftServiceVerifier;
 import hudson.Extension;
-import hudson.model.Action;
-import hudson.model.BuildListener;
 import hudson.model.AbstractBuild;
 import hudson.model.AbstractProject;
+import hudson.model.Action;
+import hudson.model.BuildListener;
 import hudson.tasks.BuildStepMonitor;
-
-import java.util.Collection;
-import java.util.Map;
-import java.util.logging.Logger;
-
 import org.jenkinsci.plugins.workflow.steps.AbstractStepDescriptorImpl;
 import org.jenkinsci.plugins.workflow.steps.Step;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 
-import com.openshift.jenkins.plugins.pipeline.ParamVerify;
-import com.openshift.jenkins.plugins.pipeline.model.GlobalConfig;
-import com.openshift.jenkins.plugins.pipeline.model.IOpenShiftServiceVerifier;
+import java.util.Collection;
+import java.util.Map;
+import java.util.logging.Logger;
 
 public class OpenShiftServiceVerifier extends OpenShiftBaseStep implements IOpenShiftServiceVerifier {
 	

--- a/src/main/java/com/openshift/jenkins/plugins/pipeline/dsl/TimedOpenShiftBaseStep.java
+++ b/src/main/java/com/openshift/jenkins/plugins/pipeline/dsl/TimedOpenShiftBaseStep.java
@@ -1,0 +1,19 @@
+package com.openshift.jenkins.plugins.pipeline.dsl;
+
+import com.openshift.jenkins.plugins.pipeline.model.ITimedOpenShiftPlugin;
+import org.kohsuke.stapler.DataBoundSetter;
+
+
+public abstract class TimedOpenShiftBaseStep extends OpenShiftBaseStep implements ITimedOpenShiftPlugin {
+
+    protected String waitTime;
+
+    final public String getWaitTime() {
+		return waitTime;
+	}
+    
+    @DataBoundSetter final public void setWaitTime(String waitTime) {
+    	this.waitTime = waitTime;
+    }
+
+}

--- a/src/main/java/com/openshift/jenkins/plugins/pipeline/model/GlobalConfig.java
+++ b/src/main/java/com/openshift/jenkins/plugins/pipeline/model/GlobalConfig.java
@@ -8,55 +8,64 @@ package com.openshift.jenkins.plugins.pipeline.model;
 // access for the DSL versions of our build steps.
 public class GlobalConfig {
 
-	public static final long BUILD_WAIT = 900000;
-	public static final long BUILD_VERIFY_WAIT = 60000;
-	public static final long DEPLOY_WAIT = 600000;
-	public static final long DEPLOY_VERIFY_WAIT = 180000;
-	public static final long SCALER_WAIT = 180000;
-	public static final int SERVICE_VERIFY_RETRY = 100;
-	
-	private static long buildWait = BUILD_WAIT;
-	private static long buildVerifyWait = BUILD_VERIFY_WAIT;
-	private static long deployWait = DEPLOY_WAIT;
-	private static long deployVerifyWait = DEPLOY_VERIFY_WAIT;
-	private static long scalerWait = SCALER_WAIT;
-	private static int serviceVerifyRetry = SERVICE_VERIFY_RETRY;
+	private static final long MINUTE = 60*1000;
+
+	public static final long UBER_DEFAULT_WAIT = 5*MINUTE;
+
+	public static final long DEFAULT_BUILD_WAIT = 15*MINUTE;
+	public static final long DEFAULT_BUILD_VERIFY_WAIT = 1*MINUTE;
+
+	public static final long DEFAULT_DEPLOY_WAIT = 10*MINUTE;
+	public static final long DEFAULT_DEPLOY_VERIFY_WAIT = 3*MINUTE;
+
+	public static final long DEFAULT_SCALER_WAIT = 3*MINUTE;
+	public static final int DEFAULT_SERVICE_VERIFY_RETRY = 100;
+
+	public static final long DEFAULT_EXEC_WAIT = 3*MINUTE;
+
+	private static long buildWait = DEFAULT_BUILD_WAIT;
+	private static long buildVerifyWait = DEFAULT_BUILD_VERIFY_WAIT;
+	private static long deployWait = DEFAULT_DEPLOY_WAIT;
+	private static long deployVerifyWait = DEFAULT_DEPLOY_VERIFY_WAIT;
+	private static long scalerWait = DEFAULT_SCALER_WAIT;
+	private static long execWait = DEFAULT_EXEC_WAIT;
+
+	private static int serviceVerifyRetry = DEFAULT_SERVICE_VERIFY_RETRY;
+
+	public static void setBuildWait(long defaultBuildWait) {
+		GlobalConfig.buildWait = defaultBuildWait;
+	}
 	public static long getBuildWait() {
 		return buildWait;
 	}
-	public static void setBuildWait(long buildWait) {
-		GlobalConfig.buildWait = buildWait;
-	}
+
+	public static void setBuildVerifyWait(long defaultBuildVerifyWait) {GlobalConfig.buildVerifyWait = defaultBuildVerifyWait;	}
 	public static long getBuildVerifyWait() {
 		return buildVerifyWait;
 	}
-	public static void setBuildVerifyWait(long buildVerifyWait) {
-		GlobalConfig.buildVerifyWait = buildVerifyWait;
+
+	public static void setExecWait(long defaultExecWait) {GlobalConfig.execWait = defaultExecWait;}
+	public static long getExecWait() { return execWait; }
+
+	public static void setDeployWait(long defaultDeployWait) {
+		GlobalConfig.deployWait = defaultDeployWait;
 	}
 	public static long getDeployWait() {
 		return deployWait;
 	}
-	public static void setDeployWait(long deployWait) {
-		GlobalConfig.deployWait = deployWait;
+
+	public static void setDeployVerifyWait(long defaultDeployVerifyWait) {	GlobalConfig.deployVerifyWait = defaultDeployVerifyWait;	}
+	public static long getDeployVerifyWait() {	return deployVerifyWait; }
+
+	public static void setScalerWait(long defaultScalerWait) {
+		GlobalConfig.scalerWait = defaultScalerWait;
 	}
-	public static long getDeployVerifyWait() {
-		return deployVerifyWait;
-	}
-	public static void setDeployVerifyWait(long deployVerifyWait) {
-		GlobalConfig.deployVerifyWait = deployVerifyWait;
-	}
-	public static long getScalerWait() {
-		return scalerWait;
-	}
-	public static void setScalerWait(long scalerWait) {
-		GlobalConfig.scalerWait = scalerWait;
-	}
+	public static long getScalerWait() { return scalerWait; }
+
+	public static void setServiceVerifyRetry(int defaultServiceVerifyRetry) {	GlobalConfig.serviceVerifyRetry = defaultServiceVerifyRetry;}
 	public static int getServiceVerifyRetry() {
 		return serviceVerifyRetry;
 	}
-	public static void setServiceVerifyRetry(int serviceVerifyRetry) {
-		GlobalConfig.serviceVerifyRetry = serviceVerifyRetry;
-	}
-	
+
 	
 }

--- a/src/main/java/com/openshift/jenkins/plugins/pipeline/model/IOpenShiftBuilder.java
+++ b/src/main/java/com/openshift/jenkins/plugins/pipeline/model/IOpenShiftBuilder.java
@@ -19,9 +19,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-public interface IOpenShiftBuilder extends IOpenShiftPlugin {
+public interface IOpenShiftBuilder extends ITimedOpenShiftPlugin {
 
-	public final static String DISPLAY_NAME = "Trigger OpenShift Build";
+	String DISPLAY_NAME = "Trigger OpenShift Build";
 	
 	default String getDisplayName() {
 		return DISPLAY_NAME;
@@ -37,10 +37,6 @@ public interface IOpenShiftBuilder extends IOpenShiftPlugin {
 		
 	String getCheckForTriggeredDeployments();
 		
-	String getWaitTime();
-	
-	String getWaitTime(Map<String, String> overrides);
-
 	List<NameValuePair>  getEnv();
 
 	default String getCommitID(Map<String,String> overrides) {
@@ -61,6 +57,10 @@ public interface IOpenShiftBuilder extends IOpenShiftPlugin {
 
 	default String getCheckForTriggeredDeployments(Map<String,String> overrides) {
 		return getOverride(getCheckForTriggeredDeployments(), overrides);
+	}
+
+	default long getDefaultWaitTime() {
+		return GlobalConfig.getBuildWait();
 	}
 
 	default void applyEnvVars( IBuildTriggerable bt ) {
@@ -218,7 +218,7 @@ public interface IOpenShiftBuilder extends IOpenShiftPlugin {
     				boolean foundPod = false;
     				startTime = System.currentTimeMillis();
 					
-					long wait = Long.parseLong(getWaitTime(overrides));
+					long wait = getTimeout(overrides);
 					
 					if (chatty)
 						listener.getLogger().println("\n OpenShiftBuilder looking for build " + bldId);

--- a/src/main/java/com/openshift/jenkins/plugins/pipeline/model/IOpenShiftDeploymentVerification.java
+++ b/src/main/java/com/openshift/jenkins/plugins/pipeline/model/IOpenShiftDeploymentVerification.java
@@ -1,17 +1,16 @@
 package com.openshift.jenkins.plugins.pipeline.model;
 
-import hudson.Launcher;
-import hudson.model.TaskListener;
-
-import java.util.Map;
-
 import com.openshift.jenkins.plugins.pipeline.MessageConstants;
 import com.openshift.restclient.IClient;
 import com.openshift.restclient.ResourceKind;
 import com.openshift.restclient.model.IDeploymentConfig;
 import com.openshift.restclient.model.IReplicationController;
+import hudson.Launcher;
+import hudson.model.TaskListener;
 
-public interface IOpenShiftDeploymentVerification extends IOpenShiftPlugin {
+import java.util.Map;
+
+public interface IOpenShiftDeploymentVerification extends ITimedOpenShiftPlugin {
 
 	final static String DISPLAY_NAME = "Verify OpenShift Deployment";
 	
@@ -24,11 +23,11 @@ public interface IOpenShiftDeploymentVerification extends IOpenShiftPlugin {
 	String getReplicaCount();
 		
 	String getVerifyReplicaCount();
-		
-	String getWaitTime();
-	
-	String getWaitTime(Map<String, String> overrides);
-	
+
+	default long getDefaultWaitTime() {
+		return GlobalConfig.getDeployVerifyWait();
+	}
+
 	default String getDepCfg(Map<String,String> overrides) {
 		return getOverride(getDepCfg(), overrides);
 	}
@@ -69,8 +68,8 @@ public interface IOpenShiftDeploymentVerification extends IOpenShiftPlugin {
 			String depId = null;
         	boolean scaledAppropriately = false;
 			if (chatty)
-				listener.getLogger().println("\nOpenShiftDeploymentVerifier wait " + getWaitTime(overrides));
-			while (System.currentTimeMillis() < (currTime + Long.parseLong(getWaitTime(overrides)))) {
+				listener.getLogger().println("\nOpenShiftDeploymentVerifier wait " + getTimeout(overrides));
+			while (System.currentTimeMillis() < (currTime + getTimeout(overrides))) {
 				// refresh dc first
 				IDeploymentConfig dc = client.get(ResourceKind.DEPLOYMENT_CONFIG, getDepCfg(overrides), getNamespace(overrides));
 				

--- a/src/main/java/com/openshift/jenkins/plugins/pipeline/model/IOpenShiftExec.java
+++ b/src/main/java/com/openshift/jenkins/plugins/pipeline/model/IOpenShiftExec.java
@@ -18,7 +18,7 @@ import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
-public interface IOpenShiftExec extends IOpenShiftPlugin {
+public interface IOpenShiftExec extends ITimedOpenShiftPlugin {
 
 	String DISPLAY_NAME = "OpenShift Exec";
 
@@ -30,13 +30,13 @@ public interface IOpenShiftExec extends IOpenShiftPlugin {
 
 	List<Argument> getArguments();
 
-	String getWaitTime();
-
 	default String getDisplayName() {
 		return DISPLAY_NAME;
 	}
 
-	String getWaitTime(Map<String, String> overrides);
+	default long getDefaultWaitTime() {
+		return GlobalConfig.getExecWait();
+	}
 
 	default boolean coreLogic(Launcher launcher, TaskListener listener, Map<String, String> overrides) {
 		listener.getLogger().println(String.format(MessageConstants.START_EXEC, DISPLAY_NAME, getNamespace(overrides)));
@@ -56,7 +56,7 @@ public interface IOpenShiftExec extends IOpenShiftPlugin {
 			return false;
 		}
 
-		int remainingWaitTime = Integer.parseInt( getWaitTime( overrides ) );
+		long remainingWaitTime = getTimeout(overrides);
 
 		final int LOOP_DELAY = 1000;
 

--- a/src/main/java/com/openshift/jenkins/plugins/pipeline/model/IOpenShiftPluginDescriptorValidation.java
+++ b/src/main/java/com/openshift/jenkins/plugins/pipeline/model/IOpenShiftPluginDescriptorValidation.java
@@ -1,0 +1,32 @@
+package com.openshift.jenkins.plugins.pipeline.model;
+
+
+import com.openshift.jenkins.plugins.pipeline.ParamVerify;
+import hudson.util.FormValidation;
+import org.kohsuke.stapler.QueryParameter;
+
+import javax.servlet.ServletException;
+import java.io.IOException;
+
+public interface IOpenShiftPluginDescriptorValidation {
+
+    default FormValidation doCheckApiURL(@QueryParameter String value)
+            throws IOException, ServletException {
+        return ParamVerify.doCheckApiURL(value);
+    }
+
+    default FormValidation doCheckNamespace(@QueryParameter String value)
+            throws IOException, ServletException {
+        return ParamVerify.doCheckNamespace(value);
+    }
+
+    default FormValidation doCheckAuthToken(@QueryParameter String value) {
+        return ParamVerify.doCheckToken(value);
+    }
+
+    default FormValidation doCheckWaitTime(@QueryParameter String value) {
+        return ParamVerify.doCheckForWaitTime(value);
+    }
+
+
+}

--- a/src/main/java/com/openshift/jenkins/plugins/pipeline/model/IOpenShiftServiceVerifier.java
+++ b/src/main/java/com/openshift/jenkins/plugins/pipeline/model/IOpenShiftServiceVerifier.java
@@ -1,5 +1,9 @@
 package com.openshift.jenkins.plugins.pipeline.model;
 
+import com.openshift.jenkins.plugins.pipeline.MessageConstants;
+import com.openshift.restclient.IClient;
+import com.openshift.restclient.ResourceKind;
+import com.openshift.restclient.model.IService;
 import hudson.Launcher;
 import hudson.model.TaskListener;
 
@@ -8,23 +12,18 @@ import java.net.InetSocketAddress;
 import java.net.Socket;
 import java.util.Map;
 
-import com.openshift.jenkins.plugins.pipeline.MessageConstants;
-import com.openshift.restclient.IClient;
-import com.openshift.restclient.ResourceKind;
-import com.openshift.restclient.model.IService;
-
 public interface IOpenShiftServiceVerifier extends IOpenShiftPlugin {
-	final static String DISPLAY_NAME = "Verify OpenShift Service";
+	String DISPLAY_NAME = "Verify OpenShift Service";
 	
 	default String getDisplayName() {
 		return DISPLAY_NAME;
 	}
 	
-	public String getSvcName();
+	String getSvcName();
 	
-	public String getRetryCount();
+	String getRetryCount();
 	
-	public String getRetryCount(Map<String, String> overrides);
+	String getRetryCount(Map<String, String> overrides);
 	
 	default String getSvcName(Map<String,String> overrides) {
 		return getOverride(getSvcName(), overrides);

--- a/src/main/java/com/openshift/jenkins/plugins/pipeline/model/ITimedOpenShiftPlugin.java
+++ b/src/main/java/com/openshift/jenkins/plugins/pipeline/model/ITimedOpenShiftPlugin.java
@@ -1,0 +1,27 @@
+package com.openshift.jenkins.plugins.pipeline.model;
+
+import java.util.Map;
+
+public interface ITimedOpenShiftPlugin extends IOpenShiftPlugin {
+
+	default long getDefaultWaitTime() {
+		return GlobalConfig.UBER_DEFAULT_WAIT;
+	}
+
+	String getWaitTime();
+
+	default long getTimeout(Map<String,String> overrides) {
+		/**
+		 * We allow user to specify variable names for
+		 * timeout values, so evaluate overrides.
+		 */
+		String field = getOverride( getWaitTime(), overrides );
+
+		if ( field != null && !field.trim().isEmpty() ) {
+			return Long.parseLong( field );
+		}
+
+		return getDefaultWaitTime();
+	}
+
+}


### PR DESCRIPTION
Fixes:
- Several areas of the code were using the following to look up timeout values: `getOverrides(getWaitTime(), overrides ).` This ultimately looked up the user specified integer value in the overrides keymap. I don't think this was intentional.
- Several areas of the code were not using the GlobalConfig values. 
- All timeout value handling has been moved into a few classes for consistency and maintainability. 

ptal @gabemontero 

fwiw, this should also simplify @oatmealraisin 's pull for timeout units.
