### PR TITLE
Added a "Test Connection" button to each build step

### DIFF
--- a/src/main/java/com/openshift/jenkins/plugins/pipeline/model/HttpUtils.java
+++ b/src/main/java/com/openshift/jenkins/plugins/pipeline/model/HttpUtils.java
@@ -1,0 +1,111 @@
+package com.openshift.jenkins.plugins.pipeline.model;
+
+import com.openshift.internal.restclient.DefaultClient;
+import com.openshift.internal.restclient.authorization.AuthorizationContext;
+import com.openshift.internal.restclient.okhttp.OpenShiftAuthenticator;
+import com.openshift.internal.restclient.okhttp.ResponseCodeInterceptor;
+import com.openshift.jenkins.plugins.pipeline.Auth;
+import com.openshift.restclient.http.IHttpConstants;
+import com.openshift.restclient.utils.SSLUtils;
+import hudson.model.TaskListener;
+import okhttp3.Dispatcher;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.Response;
+
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.X509TrustManager;
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.security.KeyManagementException;
+import java.security.NoSuchAlgorithmException;
+import java.security.cert.CertificateException;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+public class HttpUtils {
+    static String httpGet(boolean chatty, TaskListener listener, Map<String, String> overrides, String urlString, String authToken, String displayName, DefaultClient client, Auth auth, String apiURL) {
+        URL url = null;
+        try {
+            url = new URL(urlString);
+        } catch (MalformedURLException e) {
+            if(chatty)
+                e.printStackTrace(listener.getLogger());
+            return null;
+        }
+        // our lower level openshift-restclient-java usage here is not agreeable with the TrustManager maintained there,
+        // so we set up our own trust manager like we used to do in order to verify the server cert
+        try {
+            AuthorizationContext authContext = new AuthorizationContext(authToken, null, null);
+            ResponseCodeInterceptor responseCodeInterceptor = new ResponseCodeInterceptor();
+            OpenShiftAuthenticator authenticator = new OpenShiftAuthenticator();
+            Dispatcher dispatcher = new Dispatcher();
+            OkHttpClient.Builder builder = new OkHttpClient.Builder()
+                    .addInterceptor(responseCodeInterceptor)
+                    .authenticator(authenticator)
+                    .dispatcher(dispatcher)
+                    .readTimeout(IHttpConstants.DEFAULT_READ_TIMEOUT, TimeUnit.MILLISECONDS)
+                    .writeTimeout(IHttpConstants.DEFAULT_READ_TIMEOUT, TimeUnit.MILLISECONDS)
+                    .connectTimeout(IHttpConstants.DEFAULT_READ_TIMEOUT, TimeUnit.MILLISECONDS)
+                    .hostnameVerifier(auth);
+            X509TrustManager trustManager = null;
+            if (auth.useCert()) {
+                trustManager = Auth.createLocalTrustStore(auth, apiURL);
+            } else {
+                // so okhttp is a bit of a PITA when it comes to enforcing skip tls behavior
+                // (it should just allow you to set a null ssl socket factory given how
+                // RealConnection/Address/Route work), but stack overflow came to the rescue
+                // (http://stackoverflow.com/questions/25509296/trusting-all-certificates-with-okhttp)
+                // Create a trust manager that does not validate certificate chains
+                trustManager = new X509TrustManager() {
+                    @Override
+                    public void checkClientTrusted(java.security.cert.X509Certificate[] chain, String authType) throws CertificateException {
+                    }
+
+                    @Override
+                    public void checkServerTrusted(java.security.cert.X509Certificate[] chain, String authType) throws CertificateException {
+                    }
+
+                    @Override
+                    public java.security.cert.X509Certificate[] getAcceptedIssuers() {
+                        return new java.security.cert.X509Certificate[]{};
+                    }
+                };
+            }
+
+            SSLContext sslContext = null;
+            try {
+                sslContext = SSLUtils.getSSLContext(trustManager);
+            } catch (KeyManagementException e) {
+                if (chatty)
+                    e.printStackTrace(listener.getLogger());
+                return null;
+            } catch (NoSuchAlgorithmException e) {
+                if (chatty)
+                    e.printStackTrace(listener.getLogger());
+                return null;
+            }
+            builder.sslSocketFactory(sslContext.getSocketFactory(), trustManager);
+
+            OkHttpClient okClient = builder.build();
+            authContext.setClient(client);
+            responseCodeInterceptor.setClient(client);
+            authenticator.setClient(client);
+            authenticator.setOkClient(okClient);
+            Request request = client.newRequestBuilderTo(url.toString()).get().build();
+            Response result;
+            try {
+                result = okClient.newCall(request).execute();
+                String response = result.body().string();
+                return response;
+            } catch (IOException e) {
+                if (chatty)
+                    e.printStackTrace(listener.getLogger());
+            }
+            return null;
+        } finally {
+            Auth.resetLocalTrustStore();
+        }
+    }
+}

--- a/src/main/java/com/openshift/jenkins/plugins/pipeline/model/IOpenShiftPluginDescriptor.java
+++ b/src/main/java/com/openshift/jenkins/plugins/pipeline/model/IOpenShiftPluginDescriptor.java
@@ -1,13 +1,34 @@
 package com.openshift.jenkins.plugins.pipeline.model;
 
 
+import com.openshift.internal.restclient.DefaultClient;
+import com.openshift.internal.restclient.authorization.AuthorizationContext;
+import com.openshift.internal.restclient.okhttp.OpenShiftAuthenticator;
+import com.openshift.internal.restclient.okhttp.ResponseCodeInterceptor;
+import com.openshift.jenkins.plugins.pipeline.Auth;
 import com.openshift.jenkins.plugins.pipeline.ParamVerify;
+import com.openshift.restclient.ClientBuilder;
+import com.openshift.restclient.http.IHttpConstants;
+import com.openshift.restclient.utils.SSLUtils;
+import hudson.EnvVars;
 import hudson.util.FormValidation;
 import hudson.util.ListBoxModel;
+import okhttp3.Dispatcher;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import org.apache.commons.lang.StringUtils;
 import org.kohsuke.stapler.QueryParameter;
 
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.X509TrustManager;
 import javax.servlet.ServletException;
 import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.security.KeyManagementException;
+import java.security.NoSuchAlgorithmException;
+import java.security.cert.CertificateException;
+import java.util.concurrent.TimeUnit;
 
 public interface IOpenShiftPluginDescriptor {
 
@@ -37,5 +58,44 @@ public interface IOpenShiftPluginDescriptor {
         return items;
     }
 
+    default FormValidation doTestConnection(@QueryParameter String apiURL, @QueryParameter String authToken) {
 
+
+        if (StringUtils.isEmpty(apiURL)) {
+            if(!EnvVars.masterEnvVars.containsKey(IOpenShiftPlugin.KUBERNETES_SERVICE_HOST_ENV_KEY) &&
+                    !StringUtils.isEmpty(EnvVars.masterEnvVars.get(IOpenShiftPlugin.KUBERNETES_SERVICE_HOST_ENV_KEY))) {
+                return FormValidation.error("Required fields not provided");
+            }
+
+            apiURL = EnvVars.masterEnvVars.get(IOpenShiftPlugin.KUBERNETES_SERVICE_HOST_ENV_KEY);
+        }
+
+        try {
+
+            URL url = new URL(apiURL); // Test to make sure we have a good URL
+
+            Auth auth = Auth.createInstance(null, apiURL, EnvVars.masterEnvVars);
+
+            DefaultClient client = (DefaultClient) new ClientBuilder(apiURL).
+                    sslCertificateCallback(auth).
+                    withConnectTimeout(5, TimeUnit.SECONDS).
+                    usingToken(Auth.deriveBearerToken(authToken, null, false, EnvVars.masterEnvVars)).
+                    sslCertificate(apiURL, auth.getCert()).
+                    build();
+
+            if (client == null) {
+                return FormValidation.error("Connection unsuccessful");
+            }
+
+            client.getServerReadyStatus();
+
+            HttpUtils.httpGet(false, null, EnvVars.masterEnvVars, apiURL, authToken, "", client, auth, apiURL);
+        } catch (MalformedURLException e ) {
+            return FormValidation.error("Connection Unsuccessful: Bad URL");
+        } catch ( Exception e ) {
+            return FormValidation.error("Connection unsuccessful");
+        }
+
+        return FormValidation.ok("Connection successful");
+    }
 }

--- a/src/main/resources/com/openshift/jenkins/plugins/pipeline/Common/cluster.jelly
+++ b/src/main/resources/com/openshift/jenkins/plugins/pipeline/Common/cluster.jelly
@@ -13,4 +13,8 @@
     <f:textbox  />
   </f:entry>
 
+  <f:validateButton title="${%Test Connection}" progress="${%Testing...}" method="testConnection"
+    with="apiURL,authToken" />
+
+
 </j:jelly>


### PR DESCRIPTION
These check for a basic "Server Ready" status on the given URL,
skipping TLS authentification

I've abandoned the idea of having global "server profiles" for now, due to time. 

@gabemontero Unfortunately, extending IOpenShiftPlugin requires our descriptors to implement coreLogic(), which I don't think is desirable.  I'll reach out to you to discuss possibly splitting IOpenShiftPlugin into a few more classes, so that we can implement only what we need.

@gabemontero @bparees ptal? 
