### PR TITLE
Fail job when imagestream cannot be retrieved

### DIFF
--- a/src/main/java/com/openshift/jenkins/plugins/pipeline/MessageConstants.java
+++ b/src/main/java/com/openshift/jenkins/plugins/pipeline/MessageConstants.java
@@ -137,6 +137,7 @@ public static final String SCM_NO_REV = "  No revision state has been retrieved 
 public static final String SCM_COMP = "\n\nThe \"%s\" SCM is pulling the lastest revision state from OpenShift for the image stream \"%s\" and tag \"%s\" from the project \"%s\" and storing in Jenkins.";
 public static final String SCM_CHANGE = "\n\n A revision change was found this polling cycle.";
 public static final String SCM_NO_CHANGE = "\n\n No revision change found this polling cycle.";
+public static final String SCM_IMAGESTREAM_NOT_FOUND = "\n\nCannot find the last tagged image for ImageStream %s and tag %s";
 
 /*
  * These messages are for the "Tag OpenShift Image" jenkins build step implemented by OpenShiftImageTagger

--- a/src/main/resources/com/openshift/jenkins/plugins/pipeline/dsl/OpenShiftImageStreams/config.jelly
+++ b/src/main/resources/com/openshift/jenkins/plugins/pipeline/dsl/OpenShiftImageStreams/config.jelly
@@ -1,1 +1,16 @@
-../../OpenShiftImageStreams/config.jelly
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+
+  <st:include page="cluster.jelly" class="com.openshift.jenkins.plugins.pipeline.Common" />
+
+  <f:entry title="The name of the ImageStream to monitor" field="name">
+    <f:textbox  />
+  </f:entry>
+
+  <f:entry title="The specific image tag in the ImageStream to monitor" field="tag">
+    <f:textbox  />
+  </f:entry>
+
+  <st:include page="verbose.jelly" class="com.openshift.jenkins.plugins.pipeline.Common" />
+
+</j:jelly>


### PR DESCRIPTION
- Interrupts the build and sets its result as Failed if there is no ImageStream found with the tag specified.
- Saves an ImageStreamRevisionState even when there is no commit-id. This is needed for the DSL step to continue polling (otherwise you have to manually start the build).
- Fixes the jelly file for the DSL step
