### PR TITLE
Make use of resource watch instead of Thread.sleep

### DIFF
--- a/src/main/java/com/openshift/jenkins/plugins/pipeline/model/IOpenShiftPlugin.java
+++ b/src/main/java/com/openshift/jenkins/plugins/pipeline/model/IOpenShiftPlugin.java
@@ -8,6 +8,7 @@ import com.openshift.internal.restclient.okhttp.ResponseCodeInterceptor;
 import com.openshift.jenkins.plugins.pipeline.Auth;
 import com.openshift.jenkins.plugins.pipeline.MessageConstants;
 import com.openshift.jenkins.plugins.pipeline.OpenShiftBuildCanceller;
+import com.openshift.jenkins.support.IStatusHelpers;
 import com.openshift.restclient.ClientBuilder;
 import com.openshift.restclient.IClient;
 import com.openshift.restclient.OpenShiftException;
@@ -45,9 +46,7 @@ import java.security.cert.CertificateException;
 import java.util.*;
 import java.util.concurrent.TimeUnit;
 
-//import com.openshift.restclient.authorization.TokenAuthorizationStrategy;
-
-public interface IOpenShiftPlugin extends IOpenShiftParameterOverrides {
+public interface IOpenShiftPlugin extends IOpenShiftParameterOverrides, IStatusHelpers {
 
     // arg1=resource type, arg2=object name
     public static final String ANNOTATION_FAILURE = "\nWARNING: Failed to annotate %s %s with job information.";
@@ -72,12 +71,6 @@ public interface IOpenShiftPlugin extends IOpenShiftParameterOverrides {
     public static final String NAMESPACE_ENV_VAR = "PROJECT_NAME";
 
     public static final String NAMESPACE_SYNC_BUILD_CAUSE = "NAMESPACE_SYNC_BUILD_CAUSE";
-
-    // states of note
-    public static final String STATE_COMPLETE = "Complete";
-    public static final String STATE_CANCELLED = "Cancelled";
-    public static final String STATE_ERROR = "Error";
-    public static final String STATE_FAILED = "Failed";
 
     String getBaseClassName();
 
@@ -319,18 +312,6 @@ public interface IOpenShiftPlugin extends IOpenShiftParameterOverrides {
         if (!successful)
             throw new AbortException("\"" + getDisplayName() + "\" failed");
         return successful;
-    }
-
-    default boolean isBuildFinished(String bldState) {
-        if (bldState != null && (bldState.equals(STATE_COMPLETE) || bldState.equals(STATE_FAILED) || bldState.equals(STATE_ERROR) || bldState.equals(STATE_CANCELLED)))
-            return true;
-        return false;
-    }
-
-    default boolean isDeployFinished(String deployState) {
-        if (deployState != null && (deployState.equals(STATE_FAILED) || deployState.equals(STATE_COMPLETE)))
-            return true;
-        return false;
     }
 
     default boolean verifyBuild(long startTime, long wait, IClient client, String bldCfg, String bldId, String namespace, boolean chatty, TaskListener listener, String displayName, boolean checkDeps, boolean annotateRC, Map<String, String> env) throws InterruptedException {

--- a/src/main/java/com/openshift/jenkins/support/IStatusHelpers.java
+++ b/src/main/java/com/openshift/jenkins/support/IStatusHelpers.java
@@ -1,0 +1,22 @@
+package com.openshift.jenkins.support;
+
+public interface IStatusHelpers {
+
+    static final String STATE_COMPLETE = "Complete";
+    static final String STATE_CANCELLED = "Cancelled";
+    static final String STATE_ERROR = "Error";
+    public static final String STATE_FAILED = "Failed";
+
+    
+    default boolean isBuildFinished(String bldState) {
+        if (bldState != null && (bldState.equals(STATE_COMPLETE) || bldState.equals(STATE_FAILED) || bldState.equals(STATE_ERROR) || bldState.equals(STATE_CANCELLED)))
+            return true;
+        return false;
+    }
+    
+    default boolean isDeployFinished(String deployState) {
+        if (deployState != null && (deployState.equals(STATE_FAILED) || deployState.equals(STATE_COMPLETE)))
+            return true;
+        return false;
+    }
+}

--- a/src/main/java/com/openshift/jenkins/support/PodLogWatcher.java
+++ b/src/main/java/com/openshift/jenkins/support/PodLogWatcher.java
@@ -1,0 +1,122 @@
+package com.openshift.jenkins.support;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+import com.openshift.restclient.capability.CapabilityVisitor;
+import com.openshift.restclient.capability.IStoppable;
+import com.openshift.restclient.capability.resources.IPodLogRetrievalAsync;
+import com.openshift.restclient.model.IPod;
+
+import hudson.model.TaskListener;
+
+/**
+ * A manager class to watch logs
+ * from a pod and restart if disconnected
+ * 
+ * @author jeff.cantrill
+ *
+ */
+public class PodLogWatcher implements IStoppable{
+
+    private final TaskListener listener;
+    private final boolean needToFollow;
+    private final IPod pod;
+    private final Duration maxTimeReconnect; 
+    private final ExecutorService threadService;
+    private final AtomicBoolean stopping = new AtomicBoolean(false);
+    private final AtomicReference<IStoppable> stop = new AtomicReference<IStoppable>(null);
+    @SuppressWarnings("rawtypes")
+    private final AtomicReference<Future> task = new AtomicReference<Future>(null);
+    
+    private final String container;
+    private final long startTimeMillis;
+
+    /**
+     * 
+     * @param listener         A listener that will receive the log messages
+     * @param follow           True if the watcher should follow the logs
+     * @param pod              The pod from which to retrieve logs
+     * @param startTime        The time in millis the build started
+     * @param maxTimeReconnect The maximum duration to reconnect before watcher gives up.
+     */
+    public PodLogWatcher(TaskListener listener, boolean follow, IPod pod, long startTime, Duration maxTimeReconnect) {
+        this.listener = listener;
+        this.needToFollow = follow;
+        this.pod = pod;
+        this.maxTimeReconnect = maxTimeReconnect;
+        this.startTimeMillis = startTime;
+        this.threadService = Executors.newSingleThreadExecutor();
+        this.container = pod.getContainers().iterator().next().getName();
+    }
+    
+    /**
+     * Begin the watch
+     * @return  A handle to stop the watch if it can be stopped
+     */
+    public IStoppable watch() {
+        if(stop.get() == null) {
+            restart();
+        }
+        return this;
+    }
+    
+    private void restart() {
+        if(System.currentTimeMillis() - startTimeMillis < maxTimeReconnect.toMillis() && !stopping.get()) {
+            task.set(threadService.submit(runner));
+        }
+    }
+
+    private Runnable runner = new Runnable() {
+        
+        @Override
+        public void run() {
+            stop.set(pod.accept(new CapabilityVisitor<IPodLogRetrievalAsync, IStoppable>() {
+                @Override
+                public IStoppable visit(IPodLogRetrievalAsync capability) {
+                    return capability.start(new IPodLogRetrievalAsync.IPodLogListener() {
+                        @Override
+                        public void onOpen() {
+                        }
+                        
+                        @Override
+                        public void onMessage(String message) {
+                            listener.getLogger().print(message);
+                        }
+                        
+                        @Override
+                        public void onClose(int code, String reason) {
+                            restart();
+                        }
+                        
+                        @Override
+                        public void onFailure(IOException e) {
+                            restart();
+                        }
+                    }, new IPodLogRetrievalAsync.Options()
+                            .follow(needToFollow)
+                            .container(container));
+                }
+            }, null));
+        }
+    };
+
+    @Override
+    public void stop() {
+        stopping.set(true);
+        if(task.get() != null) {
+            task.get().cancel(true);
+        }
+        if(stop.get() != null){
+            stop.get().stop();
+            stop.set(null);
+        }
+        stopping.set(false);
+    }
+    
+}

--- a/src/main/java/com/openshift/jenkins/support/ResourceWatcher.java
+++ b/src/main/java/com/openshift/jenkins/support/ResourceWatcher.java
@@ -1,0 +1,119 @@
+package com.openshift.jenkins.support;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+import com.openshift.restclient.IClient;
+import com.openshift.restclient.IOpenShiftWatchListener;
+import com.openshift.restclient.IWatcher;
+import com.openshift.restclient.capability.IStoppable;
+import com.openshift.restclient.model.IResource;
+
+/**
+ * Watcher to manage watching of a specific resource kind
+ * and reconnect when the server timeouts the watch.
+ * @author jeff.cantrill
+ *
+ */
+public class ResourceWatcher implements IStoppable{
+    
+    private final Duration maxTimeReconnect; 
+    private final ExecutorService threadService;
+    private final AtomicBoolean stopping = new AtomicBoolean(false);
+    private final AtomicReference<IWatcher> stop = new AtomicReference<IWatcher>(null);
+    private final IOpenShiftWatchListener listener;
+    private final IClient client;
+    private final String namespace;
+    private final String kind;
+
+    @SuppressWarnings("rawtypes")
+    private final AtomicReference<Future> task = new AtomicReference<Future>(null);
+    private final long startTimeMillis;
+    
+    /**
+     * The callback handler is wrappered and will restart on error or disconnect before calling
+     * the listener that is passed to the watcher
+     * @param startTime          The time to use as the base for starting the watch
+     * @param maxTimeReconnect   The duration to reconnect before giving up
+     * @param client             The client to use to start the watch
+     * @param namespace          The namespace to watch
+     * @param kind               The resource kind to watch
+     * @param listener           callback handler
+     */
+    public ResourceWatcher(long startTime, Duration maxTimeReconnect, IClient client, String namespace, String kind, IOpenShiftWatchListener listener) {
+        this.maxTimeReconnect = maxTimeReconnect;
+        this.startTimeMillis = startTime;
+        this.client = client;
+        this.namespace = namespace;
+        this.kind = kind;
+        this.threadService = Executors.newSingleThreadExecutor();
+        this.listener = new IOpenShiftWatchListener(){
+
+            @Override
+            public void connected(List<IResource> resources) {
+                listener.connected(resources);
+            }
+
+            @Override
+            public void disconnected() {
+                restart();
+                listener.disconnected();
+            }
+
+            @Override
+            public void received(IResource resource, ChangeType change) {
+                listener.received(resource, change);
+            }
+
+            @Override
+            public void error(Throwable err) {
+                restart();
+                listener.error(err);
+            }
+            
+        };
+    }
+
+    /**
+     * Begin the watch
+     * @return  A handle to stop the watch if it can be stopped
+     */
+    public IStoppable watch() {
+        if(stop.get() == null) {
+            restart();
+        }
+        return this;
+    }
+    
+    private void restart() {
+        if(System.currentTimeMillis() - startTimeMillis < maxTimeReconnect.toMillis() && !stopping.get()) {
+            task.set(threadService.submit(runner));
+        }
+    }
+    
+   private Runnable runner = new Runnable() {
+        
+        @Override
+        public void run() {
+            stop.set(client.watch(namespace, listener, kind));
+        }
+    };
+    
+    @Override
+    public void stop() {
+        stopping.set(true);
+        if(task.get() != null) {
+            task.get().cancel(true);
+        }
+        if(stop.get() != null){
+            stop.get().stop();
+            stop.set(null);
+        }
+        stopping.set(false);
+    }
+}


### PR DESCRIPTION
This PR removes the use of Thread.sleep in a few places in lieu of watchers that do OpenShift watches

cc @gabemontero any chance you can help me verify the changes work.  I was able to get logs but my origin code is unable to see github.com in order to confirm its actually able to properly monitor a build.