### PR TITLE
Fixing snippet generator for tagger

### DIFF
--- a/src/main/java/com/openshift/jenkins/plugins/pipeline/dsl/OpenShiftImageTagger.java
+++ b/src/main/java/com/openshift/jenkins/plugins/pipeline/dsl/OpenShiftImageTagger.java
@@ -13,7 +13,6 @@ import org.jenkinsci.plugins.workflow.steps.Step;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 
-import javax.validation.constraints.NotNull;
 import java.util.Collection;
 import java.util.Map;
 

--- a/src/main/resources/com/openshift/jenkins/plugins/pipeline/dsl/OpenShiftImageTagger/config.jelly
+++ b/src/main/resources/com/openshift/jenkins/plugins/pipeline/dsl/OpenShiftImageTagger/config.jelly
@@ -1,1 +1,36 @@
-../../OpenShiftImageTagger/config.jelly
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+
+  <st:include page="cluster.jelly" class="com.openshift.jenkins.plugins.pipeline.Common" />
+
+  <f:entry title="The name of the ImageStream for the current image tag" field="srcStream">
+    <f:textbox  />
+  </f:entry>
+
+  <f:entry title="The name of the current image tag or actual image ID" field="srcTag">
+    <f:textbox  />
+  </f:entry>
+
+  <f:entry title="The name of the ImageStream for the new image tag" field="destStream">
+    <f:textbox  />
+  </f:entry>
+
+  <f:entry title="The name of the new image tag" field="destTag">
+    <f:textbox  />
+  </f:entry>
+
+  <f:entry title="The name of the project for the new image tag" field="destinationNamespace">
+    <f:textbox />
+  </f:entry>
+
+  <f:entry title="The authorization token for the default service account of the project for the new tag" field="destinationAuthToken">
+    <f:password />
+  </f:entry>
+
+  <f:entry title="Update destination tag whenever the source tag changes" field="alias">
+    <f:booleanRadio default="false" />
+  </f:entry>
+
+  <st:include page="verbose.jelly" class="com.openshift.jenkins.plugins.pipeline.Common" />
+
+</j:jelly>


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1396023
ptal @gabemontero 

config.jelly for the tagger DSL is a real file and no longer a symlink.