### PR TITLE
how to query service nodeport in jenkins?

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
   </parent>
   <groupId>com.openshift.jenkins</groupId>
   <artifactId>openshift-pipeline</artifactId>
-  <version>1.0.38-SNAPSHOT</version>
+  <version>1.0.38</version>
   <packaging>hpi</packaging>
 
   <build>
@@ -171,7 +171,7 @@
     <connection>scm:git:ssh://github.com/jenkinsci/openshift-pipeline-plugin.git</connection>
     <developerConnection>scm:git:ssh://git@github.com/jenkinsci/openshift-pipeline-plugin.git</developerConnection>
      <url>https://github.com/jenkinsci/openshift-pipeline-plugin</url>
-    <tag>HEAD</tag>
+    <tag>openshift-pipeline-1.0.38</tag>
   </scm>
   <developers>
     <developer>

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
   </parent>
   <groupId>com.openshift.jenkins</groupId>
   <artifactId>openshift-pipeline</artifactId>
-  <version>1.0.38</version>
+  <version>1.0.39-SNAPSHOT</version>
   <packaging>hpi</packaging>
 
   <build>
@@ -171,7 +171,7 @@
     <connection>scm:git:ssh://github.com/jenkinsci/openshift-pipeline-plugin.git</connection>
     <developerConnection>scm:git:ssh://git@github.com/jenkinsci/openshift-pipeline-plugin.git</developerConnection>
      <url>https://github.com/jenkinsci/openshift-pipeline-plugin</url>
-    <tag>openshift-pipeline-1.0.38</tag>
+    <tag>HEAD</tag>
   </scm>
   <developers>
     <developer>


### PR DESCRIPTION
  In jenkins, I am create a mysql deploymentconfig and create service with type LoadBalancer and nodeport:0, but i want access mysql with route name and nodeport, but jenkins openshift plugin create resource has no return, so, how can i query a service nodeport with openshift plugins ?

