### PR TITLE
provide some form of ssl hostname validation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -99,7 +99,8 @@
 	<dependency>
 	    <groupId>com.openshift</groupId>
 	    <artifactId>openshift-restclient-java</artifactId>
-	    <version>5.2.0.Final</version>
+	    <!--  <version>5.4.0.Final</version>-->
+	    <version>5.4.0-SNAPSHOT</version>
 	</dependency> 
     
   	<dependency>

--- a/src/main/java/com/openshift/jenkins/plugins/pipeline/model/IOpenShiftPluginDescriptor.java
+++ b/src/main/java/com/openshift/jenkins/plugins/pipeline/model/IOpenShiftPluginDescriptor.java
@@ -111,12 +111,16 @@ public interface IOpenShiftPluginDescriptor extends IOpenShiftParameterOverrides
                         
             Auth auth = Auth.createInstance(null, getOverride(apiURL, allOverrides), allOverrides);
             
-            DefaultClient client = (DefaultClient) new ClientBuilder(getOverride(apiURL, allOverrides)).
+            ClientBuilder cb = new ClientBuilder(getOverride(apiURL, allOverrides)).
                     sslCertificateCallback(auth).
                     withConnectTimeout(5, TimeUnit.SECONDS).
                     usingToken(Auth.deriveBearerToken(getOverride(authToken, allOverrides), null, false, allOverrides)).
-                    sslCertificate(getOverride(apiURL, allOverrides), auth.getCert()).
-                    build();
+                    sslCertificate(getOverride(apiURL, allOverrides), auth.getCert());
+            
+            if (auth.useCert())
+                cb.sslCertCallbackWithDefaultHostnameVerifier(true);
+            
+            DefaultClient client = (DefaultClient) cb.build();
 
             if (client == null) {
                 return FormValidation.error("Connection unsuccessful");


### PR DESCRIPTION
@bparees @csrwng PTAL

This stems from the hornets' nest I stirred up in https://github.com/openshift/origin/issues/12476 with comment https://github.com/openshift/origin/issues/12476#issuecomment-272461025

Clayton ultimately chimed in with comment https://github.com/openshift/origin/issues/12476#issuecomment-272547257, asking we do something asap.

Based on my parsing of some SSL related javadoc, and analysis of results from the base `oc cluster up` start up, I've crafted this change to provide some hostname based validation of the remote/server side of the SSL connection.  

Aside from using the hostname that the plugin uses for the api server, trying to interpret some proxy based comments I thought Ben made somewhere, I also added the ability to manually configure a list of hosts that the remote certs needed to ref.

Thoughts?