### PR TITLE
switch to service.spec.clusterIP, as portalIP has been removed

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -99,7 +99,8 @@
 	<dependency>
 	    <groupId>com.openshift</groupId>
 	    <artifactId>openshift-restclient-java</artifactId>
-	    <version>5.2.0.Final</version>
+	    <!--  <version>5.4.0.Final</version>-->
+	    <version>5.4.0-SNAPSHOT</version>
 	</dependency> 
     
   	<dependency>

--- a/src/main/java/com/openshift/jenkins/plugins/pipeline/model/IOpenShiftServiceVerifier.java
+++ b/src/main/java/com/openshift/jenkins/plugins/pipeline/model/IOpenShiftServiceVerifier.java
@@ -40,7 +40,7 @@ public interface IOpenShiftServiceVerifier extends IOpenShiftPlugin {
         if (client != null) {
             // get Service
             IService svc = client.get(ResourceKind.SERVICE, getSvcName(overrides), getNamespace(overrides));
-            String ip = svc.getPortalIP();
+            String ip = svc.getClusterIP();
             int port = svc.getPort();
             spec = ip + ":" + port;
             int tryCount = 0;


### PR DESCRIPTION
Fixes https://github.com/openshift/jenkins-plugin/issues/122

service.spec.portalIP was removed somewhat recently in https://github.com/openshift/origin