### PR TITLE
    jenkins-plugin: add retry layer/adapter for REST invocations

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -99,8 +99,7 @@
 	<dependency>
 	    <groupId>com.openshift</groupId>
 	    <artifactId>openshift-restclient-java</artifactId>
-	    <!--  <version>5.4.0.Final</version>-->
-	    <version>5.4.0-SNAPSHOT</version>
+	    <version>5.6.0.Final</version>
 	</dependency> 
     
   	<dependency>

--- a/src/main/java/com/openshift/jenkins/plugins/pipeline/MessageConstants.java
+++ b/src/main/java/com/openshift/jenkins/plugins/pipeline/MessageConstants.java
@@ -159,4 +159,10 @@ public static final String EXIT_SERVICE_VERIFY_BAD = "\n\nExiting \"%s\" unsucce
 public static final String SOCKET_TIMEOUT = " a socket level communication timeout to \"%s\" occurred.";
 public static final String HTTP_ERR = " the HTTP level communication error \"%s\" for \"%s\" occurred.";
 
+/*
+ * These messages are centered around restclient retry
+ */
+public static final String RETRY = "\nAn exception occurred invoking a REST operation against the OpenShift master.  The operation will be retried.  Exception message \"%s\".";
+public static final String GIVE_UP_RETRY = "\nAfter a few retries, giving up invoking the REST operation against the OpenShift master.  Final exception message \"%s\".";
+
 }

--- a/src/main/java/com/openshift/jenkins/plugins/pipeline/model/IOpenShiftExec.java
+++ b/src/main/java/com/openshift/jenkins/plugins/pipeline/model/IOpenShiftExec.java
@@ -91,7 +91,7 @@ public interface IOpenShiftExec extends ITimedOpenShiftPlugin, IPodExec.IPodExec
         if (client == null) {
             listener.getLogger().println(String.format(MessageConstants.CANNOT_GET_CLIENT, displayName, getApiURL(overrides)));
         }
-        return client;
+        return new RetryIClient(client, listener);
         
     }
 

--- a/src/main/java/com/openshift/jenkins/plugins/pipeline/model/IOpenShiftPlugin.java
+++ b/src/main/java/com/openshift/jenkins/plugins/pipeline/model/IOpenShiftPlugin.java
@@ -154,7 +154,7 @@ public interface IOpenShiftPlugin extends IOpenShiftParameterOverrides {
         if (client == null) {
             listener.getLogger().println(String.format(MessageConstants.CANNOT_GET_CLIENT, displayName, getApiURL(overrides)));
         }
-        return client;
+        return new RetryIClient(client, listener);
     }
 
     //TODO move to openshift-restclient-java IReplicationController
@@ -660,7 +660,8 @@ public interface IOpenShiftPlugin extends IOpenShiftParameterOverrides {
             ResponseCodeInterceptor responseCodeInterceptor = new ResponseCodeInterceptor();
             OpenShiftAuthenticator authenticator = new OpenShiftAuthenticator();
             Dispatcher dispatcher = new Dispatcher();
-            DefaultClient client = (DefaultClient) this.getClient(listener, getDisplayName(), overrides);
+            RetryIClient iclient = (RetryIClient) this.getClient(listener, getDisplayName(), overrides);
+            DefaultClient client = iclient.getDefaultClient();
             OkHttpClient.Builder builder = new OkHttpClient.Builder()
                     .addInterceptor(responseCodeInterceptor)
                     .authenticator(authenticator)

--- a/src/main/java/com/openshift/jenkins/plugins/pipeline/model/RetryIClient.java
+++ b/src/main/java/com/openshift/jenkins/plugins/pipeline/model/RetryIClient.java
@@ -1,0 +1,269 @@
+package com.openshift.jenkins.plugins.pipeline.model;
+
+import hudson.model.TaskListener;
+
+import java.net.URL;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Callable;
+
+import com.openshift.internal.restclient.DefaultClient;
+import com.openshift.jenkins.plugins.pipeline.MessageConstants;
+import com.openshift.restclient.BadRequestException;
+import com.openshift.restclient.IClient;
+import com.openshift.restclient.IOpenShiftWatchListener;
+import com.openshift.restclient.IResourceFactory;
+import com.openshift.restclient.IWatcher;
+import com.openshift.restclient.NotFoundException;
+import com.openshift.restclient.OpenShiftException;
+import com.openshift.restclient.UnsupportedVersionException;
+import com.openshift.restclient.api.ITypeFactory;
+import com.openshift.restclient.authorization.IAuthorizationContext;
+import com.openshift.restclient.authorization.ResourceForbiddenException;
+import com.openshift.restclient.authorization.UnauthorizedException;
+import com.openshift.restclient.capability.CapabilityVisitor;
+import com.openshift.restclient.capability.ICapability;
+import com.openshift.restclient.model.IList;
+import com.openshift.restclient.model.IResource;
+import com.openshift.restclient.model.JSONSerializeable;
+
+public class RetryIClient implements IClient {
+    
+    private static int MAX_RETRY = 3;
+
+    private final IClient client;
+    private final TaskListener listener;
+    
+    private OpenShiftException handleError(Throwable t, Object call) throws OpenShiftException {
+        OpenShiftException ose = null;
+        if ((t instanceof BadRequestException) ||
+            (t instanceof ResourceForbiddenException) ||
+            (t instanceof UnauthorizedException) ||
+            (t instanceof NotFoundException)) {
+            throw (OpenShiftException)t;                    
+        }
+        if (!(t instanceof OpenShiftException)) {
+            ose = new OpenShiftException(t, "retry", call);
+        } else {
+            ose = (OpenShiftException)t;
+        }
+        listener.getLogger().println(String.format(MessageConstants.RETRY, t.getMessage()));
+        try {
+            Thread.sleep(1000);
+        } catch (InterruptedException e) {
+            throw new OpenShiftException(e, "retry", call);
+        }
+        return ose;
+    }
+    
+    private Object retry(Callable<Object> call) throws OpenShiftException {
+        int retryCount = 0;
+        OpenShiftException ose = null;
+        while (retryCount < MAX_RETRY) {
+            try {
+                Object o = call.call();
+                return o;
+            } catch (Throwable t) {
+                retryCount++;
+                ose = handleError(t, call);
+            }
+        }
+        if (ose.getCause() != null)
+            listener.getLogger().println(String.format(MessageConstants.GIVE_UP_RETRY, ose.getCause().getMessage()));
+        else 
+            listener.getLogger().println(String.format(MessageConstants.GIVE_UP_RETRY, ose.getMessage()));
+        throw ose;
+    }
+    
+    private void retry(Runnable call) throws OpenShiftException {
+        int retryCount = 0;
+        OpenShiftException ose = null;
+        while (retryCount < MAX_RETRY) {
+            try {
+                call.run();
+                return;
+            } catch (Throwable t) {
+                retryCount++;
+                ose = handleError(t, call);
+            }
+        }
+        if (ose.getCause() != null)
+            listener.getLogger().println(String.format(MessageConstants.GIVE_UP_RETRY, ose.getCause().getMessage()));
+        else 
+            listener.getLogger().println(String.format(MessageConstants.GIVE_UP_RETRY, ose.getMessage()));
+        throw ose;
+    }
+    
+    public RetryIClient(IClient c, TaskListener l) {
+        client = c;
+        listener = l;
+    }
+    
+    // some of the error handling, core request building, and auth retrieval in restclient needs the impl class ... 
+    // does not come into play with actual REST interactions
+    public DefaultClient getDefaultClient() {
+        return (DefaultClient)client;
+    }
+
+    @Override
+    public <T extends ICapability> T getCapability(Class<T> capability) {
+        return client.getCapability(capability);
+    }
+
+    @Override
+    public boolean supports(Class<? extends ICapability> capability) {
+        return client.supports(capability);
+    }
+
+    @Override
+    public <T extends ICapability, R> R accept(CapabilityVisitor<T, R> visitor,
+            R unsupportedCapabililityValue) {
+        return client.accept(visitor, unsupportedCapabililityValue);
+    }
+
+    @Override
+    public IWatcher watch(String namespace, IOpenShiftWatchListener listener,
+            String... kinds) {
+        return client.watch(namespace, listener, kinds);
+    }
+
+    @Override
+    public IWatcher watch(IOpenShiftWatchListener listener, String... kinds) {
+        return client.watch(listener, kinds);
+    }
+
+    @Override
+    public <T extends IResource> List<T> list(String kind) {
+        return (List<T>) retry(() -> client.list(kind));
+    }
+
+    @Override
+    public <T extends IResource> List<T> list(String kind,
+            Map<String, String> labels) {
+        return (List<T>) retry(() -> client.list(kind, labels));
+    }
+
+    @Override
+    public <T extends IResource> List<T> list(String kind, String namespace) {
+        return (List<T>) retry(() -> client.list(kind, namespace));
+    }
+
+    @Override
+    public <T extends IResource> List<T> list(String kind, String namespace,
+            Map<String, String> labels) {
+        return (List<T>) retry(() -> client.list(kind, namespace, labels));
+    }
+
+    @Override
+    public <T extends IResource> List<T> list(String kind, String namespace,
+            String labelQuery) {
+        return (List<T>) retry(() -> client.list(kind, namespace, labelQuery));
+    }
+
+    @Override
+    public <T extends IResource> T get(String kind, String name,
+            String namespace) {
+        return (T) retry(() -> client.get(kind, name, namespace));
+    }
+
+    @Override
+    public IList get(String kind, String namespace) {
+        return (IList) retry(() -> client.get(kind, namespace));
+    }
+
+    @Override
+    public <T extends IResource> T create(T resource) {
+        return (T) retry(() -> client.create(resource));
+    }
+
+    @Override
+    public <T extends IResource> T create(T resource, String namespace) {
+        return (T) retry(() -> client.create(resource, namespace));
+    }
+
+    @Override
+    public <T extends IResource> T create(String kind, String namespace,
+            String name, String subresource, IResource payload) {
+        return (T) retry(() -> client.create(kind, namespace, name, subresource, payload));
+    }
+
+    @Override
+    public Collection<IResource> create(IList list, String namespace) {
+        return (Collection<IResource>) retry(() -> client.create(list, namespace));
+    }
+
+    @Override
+    public <T extends IResource> T update(T resource) {
+        return (T) retry(() -> client.update(resource));
+    }
+
+    @Override
+    public <T extends IResource> void delete(T resource) {
+        retry(() -> client.delete(resource));
+    }
+
+    @Override
+    public <T extends IResource> T execute(String httpMethod, String kind,
+            String namespace, String name, String subresource, IResource payload) {
+        return (T) retry(() -> client.execute(httpMethod, kind, namespace, name, subresource, payload));
+    }
+
+    @Override
+    public <T extends IResource> T execute(String httpMethod, String kind,
+            String namespace, String name, String subresource,
+            IResource payload, Map<String, String> params) {
+        return (T) retry(() -> client.execute(httpMethod, kind, namespace, name, subresource, payload, params));
+    }
+
+    @Override
+    public <T extends IResource> T execute(String httpMethod, String kind,
+            String namespace, String name, String subresource,
+            IResource payload, String subcontext) {
+        return (T) retry(() -> client.execute(httpMethod, kind, namespace, name, subresource, payload, subcontext));
+    }
+
+    @Override
+    public <T> T execute(ITypeFactory factory, String httpMethod, String kind,
+            String namespace, String name, String subresource,
+            String subContext, JSONSerializeable payload,
+            Map<String, String> params) {
+        return (T) retry(() -> client.execute(factory, httpMethod, kind, namespace, name, subresource, subContext, payload, params));
+    }
+
+    @Override
+    public URL getBaseURL() {
+        return client.getBaseURL();
+    }
+
+    @Override
+    public String getResourceURI(IResource resource) {
+        return client.getResourceURI(resource);
+    }
+
+    @Override
+    public String getOpenShiftAPIVersion() throws UnsupportedVersionException {
+        return client.getOpenShiftAPIVersion();
+    }
+
+    @Override
+    public IAuthorizationContext getAuthorizationContext() {
+        return client.getAuthorizationContext();
+    }
+
+    @Override
+    public IResourceFactory getResourceFactory() {
+        return client.getResourceFactory();
+    }
+
+    @Override
+    public String getServerReadyStatus() {
+        return (String) retry(() -> client.getServerReadyStatus());
+    }
+
+    @Override
+    public IClient clone() {
+        return new RetryIClient(client.clone(), listener);
+    }
+
+}


### PR DESCRIPTION
    Bug 1454485
    Bugzilla link https://bugzilla.redhat.com/show_bug.cgi?id=1454485
    Detailed explanation
    Implement a general retry mechanism for failing HTTP REST operations
    against the OpenShift master

@bparees @oatmealraisin FYI