### PR TITLE
add diagnostic logging for test connection

### DIFF
--- a/src/main/java/com/openshift/jenkins/plugins/pipeline/model/IOpenShiftPluginDescriptor.java
+++ b/src/main/java/com/openshift/jenkins/plugins/pipeline/model/IOpenShiftPluginDescriptor.java
@@ -157,6 +157,8 @@ public interface IOpenShiftPluginDescriptor extends
 
             if (auth.useCert())
                 cb.sslCertCallbackWithDefaultHostnameVerifier(true);
+            
+            LOGGER.info("OpenShift Pipeline Plugin: testing connection for " + getOverride(apiURL, allOverrides));
 
             DefaultClient client = (DefaultClient) cb.build();
 
@@ -165,6 +167,7 @@ public interface IOpenShiftPluginDescriptor extends
             }
 
             String status = client.getServerReadyStatus();
+            LOGGER.info("OpenShift Pipeline Plugin: server ready status: " + status);
             if (status == null || !status.equalsIgnoreCase("ok")) {
                 return FormValidation
                         .error("Connection made but server status is:  "
@@ -181,6 +184,10 @@ public interface IOpenShiftPluginDescriptor extends
                     .build();
             Response result = client.adapt(OkHttpClient.class).newCall(request)
                     .execute();
+            if (result != null)
+                LOGGER.info("OpenShift Pipeline Plugin: HTTP get to " + getOverride(apiURL, allOverrides) + "/apis returned HTTP code " + result.code() + " and message " + result.message());
+            else
+                LOGGER.info("OpenShift Pipeline Plugin: HTTP get to " + getOverride(apiURL, allOverrides) + "/apis got a null response");
 
         } catch (Throwable e) {
             LOGGER.log(Level.SEVERE, "doTestConnection", e);


### PR DESCRIPTION
debug for https://github.com/openshift/origin/issues/17488

@openshift/sig-developer-experience fyi

and note, the PR testing will invoke the same test case on the ci system that failed in https://github.com/openshift/origin/issues/17488 with this change .... if the failure is at all more than completely random, we should be able to diagnose here

I still think it is useful to add these logs (they show up in the jenkins log, not the job log), but not merging this change but still diagnosing https://github.com/openshift/origin/issues/17488 is an option